### PR TITLE
Changing upstream share finding function

### DIFF
--- a/cronjobs/findblock.php
+++ b/cronjobs/findblock.php
@@ -23,7 +23,8 @@ limitations under the License.
 require_once('shared.inc.php');
 
 // Fetch our last block found from the DB as a starting point
-$strLastBlockHash = @$block->getLast()->blockhash;
+$aLastBlock = @$block->getLast();
+$strLastBlockHash = $aLastBlock['blockhash'];
 if (!$strLastBlockHash) { 
   $strLastBlockHash = '';
 }


### PR DESCRIPTION
- Fetch all blocks unaccounted for in ASC oder (low to high height)
- Use lowest height block to find lowest ID upstream accepted share
- Use this share as the finding share for a block
- Set share as last found upstream share for further blocks
  - This only applies if shares are not deleted at all which they should!
