### PR TITLE
Changed backend logics for block finding and payout

### DIFF
--- a/cronjobs/propotional_payout.php
+++ b/cronjobs/propotional_payout.php
@@ -32,29 +32,30 @@ if (empty($aAllBlocks)) {
 $count = 0;
 foreach ($aAllBlocks as $iIndex => $aBlock) {
   if (!$aBlock['accounted']) {
-    if ($share->setUpstream($share->getLastUpstreamId())) {
-      $iCurrentUpstreamId = $share->getUpstreamId();
-    } else {
-      verbose("Unable to fetch blocks upstream share\n");
-      verbose($share->getError() . "\n");
-      continue;
-    }
-    $aAccountShares = $share->getSharesForAccounts($share->getLastUpstreamId(), $iCurrentUpstreamId);
-    $iRoundShares = $share->getRoundShares($share->getLastUpstreamId(), $iCurrentUpstreamId);
+    $iPreviousShareId = $aAllBlocks[$iIndex - 1]['share_id'] ? $aAllBlocks[$iIndex - 1]['share_id'] : 0;
+    $iCurrentUpstreamId = $aBlock['share_id'];
+    $aAccountShares = $share->getSharesForAccounts($iPreviousShareId, $aBlock['share_id']);
+    $iRoundShares = $share->getRoundShares($iPreviousShareId, $aBlock['share_id']);
+
+    // Table header for block details
     verbose("ID\tHeight\tTime\t\tShares\tFinder\t\tShare ID\tPrev Share\t\tStatus\n");
-    verbose($aBlock['id'] . "\t" . $aBlock['height'] . "\t" . $aBlock['time'] . "\t" . $iRoundShares . "\t" . $share->getUpstreamFinder() . "\t" . $share->getUpstreamId() . "\t\t" . $share->getLastUpstreamId());
+    verbose($aBlock['id'] . "\t" . $aBlock['height'] . "\t" . $aBlock['time'] . "\t" . $iRoundShares . "\t" . $user->getUserName($aBlock['account_id']) . "\t" . $iCurrentUpstreamId . "\t\t" . $iPreviousShareId);
+
     if (empty($aAccountShares)) {
       verbose("\nNo shares found for this block\n\n");
       sleep(2);
       continue;
     }
     $strStatus = "OK";
-    if (!$block->setFinder($aBlock['id'], $user->getUserId($share->getUpstreamFinder())))
-      $strStatus = "Finder Failed";
+    // Store share information for this block
     if (!$block->setShares($aBlock['id'], $iRoundShares))
       $strStatus = "Shares Failed";
     verbose("\t\t$strStatus\n\n");
+
+    // Table header for account shares
     verbose("ID\tUsername\tValid\tInvalid\tPercentage\tPayout\t\tDonation\tFee\t\tStatus\n");
+
+    // Loop through all accounts that have found shares for this round
     foreach ($aAccountShares as $key => $aData) {
       // Payout based on shares, PPS system
       $aData['percentage'] = number_format(round(( 100 / $iRoundShares ) * $aData['valid'], 8), 8);
@@ -94,14 +95,13 @@ foreach ($aAllBlocks as $iIndex => $aBlock) {
         if (!$transaction->addTransaction($aData['id'], $aData['donation'], 'Donation', $aBlock['id']))
           $strStatus = "Donation Failed";
       verbose("\t$strStatus\n");
-      // Set this blocks share ID as the last found upstream ID
     }
 
     // Move counted shares to archive before this blockhash upstream share
-    if ($config['archive_shares']) $share->moveArchive($iCurrentUpstreamId, $aBlock['id'], $share->getLastUpstreamId());
+    if ($config['archive_shares']) $share->moveArchive($iCurrentUpstreamId, $aBlock['id'], $iPreviousShareId);
     // Delete all accounted shares
-    if (!$share->deleteAccountedShares($iCurrentUpstreamId, $share->getLastUpstreamId())) {
-      verbose("\nERROR : Failed to delete accounted shares from " . $share->getLastUpstreamId() . " to $iCurrentUpstreamId, aborting!\n");
+    if (!$share->deleteAccountedShares($iCurrentUpstreamId, $iPreviousShareId)) {
+      verbose("\nERROR : Failed to delete accounted shares from $iPreviousShareId to $iCurrentUpstreamId, aborting!\n");
       exit(1);
     }
     // Mark this block as accounted for
@@ -110,6 +110,5 @@ foreach ($aAllBlocks as $iIndex => $aBlock) {
     }
 
     verbose("------------------------------------------------------------------------\n\n");
-    $share->setLastUpstreamId();
   }
 }

--- a/public/include/classes/block.class.php
+++ b/public/include/classes/block.class.php
@@ -130,6 +130,16 @@ class Block {
     return false;
   }
 
+  public function getLastUpstreamId() {
+    $stmt = $this->mysqli->prepare("
+      SELECT MAX(share_id) AS share_id FROM $this->table
+      ");
+    if ($this->checkStmt($stmt) && $stmt->execute() && $stmt->bind_result($share_id) && $stmt->fetch())
+      return $share_id ? $share_id : 0;
+    // Catchall
+    return false;
+  }
+
   /**
    * Update a single column within a single row
    * @param block_id int Block ID to update
@@ -160,6 +170,16 @@ class Block {
    **/
   public function setFinder($block_id, $account_id=NULL) {
     return $this->updateSingle($block_id, 'account_id', $account_id);
+  }
+
+  /**
+   * Set finding share for a block
+   * @param block_id int Block ID
+   * @param share_id int Upstream valid share ID
+   * @return bool
+   **/
+  public function setShareId($block_id, $share_id) {
+    return $this->updateSingle($block_id, 'share_id', $share_id);
   }
 
   /**


### PR DESCRIPTION
- Findblocks cronjob changes
  - Find & Store upstream share
  - Use last found `share_id` as starting ID or `0`
  - Find & Store upstream finder
  - Use last found `share_id` as starting ID or `0`
- Use stored information when running propotional payout
  - Fetch current checked blocks upstream share from block table
  - Fetch previous upstream share of previous block from block table
  - Calculated payouts in that range of IDs
- Updated `block.class.php` to store share_id in block and fetch highest `share_id`
