### PR TITLE
Renamed workers table to pool_worker

### DIFF
--- a/public/include/classes/worker.class.php
+++ b/public/include/classes/worker.class.php
@@ -6,7 +6,7 @@ if (!defined('SECURITY'))
 
 class Worker {
   private $sError = '';
-  private $table = 'workers';
+  private $table = 'pool_worker';
 
   public function __construct($debug, $mysqli, $user, $share, $config) {
     $this->debug = $debug;

--- a/sql/mmcfe_ng_structure.sql
+++ b/sql/mmcfe_ng_structure.sql
@@ -161,10 +161,10 @@ CREATE TABLE IF NOT EXISTS `transactions` (
 -- --------------------------------------------------------
 
 --
--- Table structure for table `workers`
+-- Table structure for table `pool_worker`
 --
 
-CREATE TABLE IF NOT EXISTS `workers` (
+CREATE TABLE IF NOT EXISTS `pool_worker` (
   `id` int(255) NOT NULL AUTO_INCREMENT,
   `account_id` int(255) NOT NULL,
   `username` char(50) DEFAULT NULL,


### PR DESCRIPTION
- This will fix issues with mining pools using the default name
- Back in line with default configurations for most mining pool software
- Fixes #93

This commit includes the new DB structure for the newly named table. As discussed in #93 you can run

```
RENAME TABLE workers TO pool_worker
```

to keep you existing table data.
