### PR TITLE
Removed PHP Notice warning when running cron

### DIFF
--- a/cronjobs/proportional_payout.php
+++ b/cronjobs/proportional_payout.php
@@ -32,7 +32,7 @@ if (empty($aAllBlocks)) {
 $count = 0;
 foreach ($aAllBlocks as $iIndex => $aBlock) {
   if (!$aBlock['accounted']) {
-    $iPreviousShareId = $aAllBlocks[$iIndex - 1]['share_id'] ? $aAllBlocks[$iIndex - 1]['share_id'] : 0;
+    $iPreviousShareId = @$aAllBlocks[$iIndex - 1]['share_id'] ? $aAllBlocks[$iIndex - 1]['share_id'] : 0;
     $iCurrentUpstreamId = $aBlock['share_id'];
     $aAccountShares = $share->getSharesForAccounts($iPreviousShareId, $aBlock['share_id']);
     $iRoundShares = $share->getRoundShares($iPreviousShareId, $aBlock['share_id']);


### PR DESCRIPTION
This fixes #102, we don't need to see this warning since it doesn't
affect the job at all.
