### PR TITLE
Ensure no old blocks shares are counter for new ones

### DIFF
--- a/cronjobs/findblock.php
+++ b/cronjobs/findblock.php
@@ -87,7 +87,11 @@ foreach ($aAllBlocks as $iIndex => $aBlock) {
       continue;
     }
     // Fetch share information
-    $iPreviousShareId = @$aAllBlocks[$iIndex - 1]['share_id'] ? $aAllBlocks[$iIndex - 1]['share_id'] : 0;
+    if (!$iPreviousShareId = $block->getLastShareId()) {
+      $iPreviousShareId = 0;
+      verbose("\nUnable to find highest share ID found so far\n");
+      verbose("If this is your first block, this is normal\n\n");
+    }
     $iRoundShares = $share->getRoundShares($iPreviousShareId, $iCurrentUpstreamId);
 
     // Store new information

--- a/public/include/classes/block.class.php
+++ b/public/include/classes/block.class.php
@@ -44,6 +44,18 @@ class Block {
   }
 
   /**
+   * Get our last, highest share ID inserted for a block
+   * @param none
+   * @return int data Share ID
+   **/
+  public function getLastShareId() {
+    $stmt = $this->mysqli->prepare("SELECT MAX(share_id) AS share_id FROM $this->table LIMIT 1");
+    if ($this->checkStmt($stmt) && $stmt->execute() && $result = $stmt->get_result())
+      return $result->fetch_object()->share_id;
+    return false;
+  }
+
+  /**
    * Fetch all unaccounted blocks
    * @param order string Sort order, default ASC
    * @return data array Array with database fields as keys


### PR DESCRIPTION
When finding more than a single block between runs it added shares to a
new block from a previous one. Properly fetch the last highest share ID
from the database prior to scanning for shares assigned to a block.

Fixes #124
