### PR TITLE
Fixing critical issue with manual- and autopayouts

### DIFF
--- a/cronjobs/auto_payout.php
+++ b/cronjobs/auto_payout.php
@@ -27,6 +27,9 @@ if ($bitcoin->can_connect() !== true) {
   exit(1);
 }
 
+// Mark this job as active
+$setting->setValue('auto_payout_active', 1);
+
 // Fetch all users with setup AP
 $users = $user->getAllAutoPayout();
 
@@ -69,3 +72,8 @@ if (! empty($users)) {
 } else {
   verbose("No user has configured their AP > 0\n");
 }
+
+// Mark this job as inactive
+$setting->setValue('auto_payout_active', 0);
+
+?>

--- a/public/include/pages/account/edit.inc.php
+++ b/public/include/pages/account/edit.inc.php
@@ -28,7 +28,12 @@ if ( ! $user->checkPin($_SESSION['USERDATA']['id'], $_POST['authPin']) && $_POST
         if ($continue == true) {
           // Send balance to address, mind 0.1 fee for transaction!
           try {
-            $bitcoin->sendtoaddress($sCoinAddress, $dBalance);
+            if ($setting->getValue('auto_payout_active') == 0) {
+              $bitcoin->sendtoaddress($sCoinAddress, $dBalance);
+            } else {
+              $_SESSION['POPUP'][] = array('CONTENT' => 'Auto-payout active, please contact site support immidiately to revoke invalid transactions.', 'TYPE' => 'errormsg');
+              $continue = false;
+            }
           } catch (BitcoinClientException $e) {
             $_SESSION['POPUP'][] = array('CONTENT' => 'Failed to send LTC, please contact site support immidiately', 'TYPE' => 'errormsg');
             $continue = false;


### PR DESCRIPTION
This is a proposed fix for #128:
- Mark auto_payout running via DB setting, unlock when done
- Just before actually sending money, check for running cron

Please refer to the ticket for details
