### PR TITLE
Fixing manual payout race condition

### DIFF
--- a/public/include/pages/account/edit.inc.php
+++ b/public/include/pages/account/edit.inc.php
@@ -13,45 +13,51 @@ if ( ! $user->checkPin($_SESSION['USERDATA']['id'], $_POST['authPin']) && $_POST
 } else {
   switch ($_POST['do']) {
   case 'cashOut':
-    $continue = true;
-    $dBalance = $transaction->getBalance($_SESSION['USERDATA']['id']);
-    $sCoinAddress = $user->getCoinAddress($_SESSION['USERDATA']['id']);
-    // Ensure we can cover the potential transaction fee of 0.1 LTC with the balance
-    if ($dBalance > 0.1) {
-      if ($bitcoin->can_connect() === true) {
-        try {
-          $bitcoin->validateaddress($sCoinAddress);
-        } catch (BitcoinClientException $e) {
-          $_SESSION['POPUP'][] = array('CONTENT' => 'Invalid payment address: ' . $sUserSendAddress, 'TYPE' => 'errormsg');
-          $continue = false;
-        }
-        if ($continue == true) {
-          // Send balance to address, mind 0.1 fee for transaction!
+    if ($setting->getValue('manual_payout_active') == 1) {
+      $_SESSION['POPUP'][] = array('CONTENT' => 'A manual payout is in progress. Please try again later.', 'TYPE' => 'errormsg');
+    } else {
+      $setting->setValue('manual_payout_active', 1);
+      $continue = true;
+      $dBalance = $transaction->getBalance($_SESSION['USERDATA']['id']);
+      $sCoinAddress = $user->getCoinAddress($_SESSION['USERDATA']['id']);
+      // Ensure we can cover the potential transaction fee of 0.1 LTC with the balance
+      if ($dBalance > 0.1) {
+        if ($bitcoin->can_connect() === true) {
           try {
-            if ($setting->getValue('auto_payout_active') == 0) {
-              $bitcoin->sendtoaddress($sCoinAddress, $dBalance);
-            } else {
-              $_SESSION['POPUP'][] = array('CONTENT' => 'Auto-payout active, please contact site support immidiately to revoke invalid transactions.', 'TYPE' => 'errormsg');
-              $continue = false;
-            }
+            $bitcoin->validateaddress($sCoinAddress);
           } catch (BitcoinClientException $e) {
-            $_SESSION['POPUP'][] = array('CONTENT' => 'Failed to send LTC, please contact site support immidiately', 'TYPE' => 'errormsg');
+            $_SESSION['POPUP'][] = array('CONTENT' => 'Invalid payment address: ' . $sUserSendAddress, 'TYPE' => 'errormsg');
             $continue = false;
           }
+          if ($continue == true) {
+            // Send balance to address, mind 0.1 fee for transaction!
+            try {
+              if ($setting->getValue('auto_payout_active') == 0) {
+                $bitcoin->sendtoaddress($sCoinAddress, $dBalance);
+              } else {
+                $_SESSION['POPUP'][] = array('CONTENT' => 'Auto-payout active, please contact site support immidiately to revoke invalid transactions.', 'TYPE' => 'errormsg');
+                $continue = false;
+              }
+            } catch (BitcoinClientException $e) {
+              $_SESSION['POPUP'][] = array('CONTENT' => 'Failed to send LTC, please contact site support immidiately', 'TYPE' => 'errormsg');
+              $continue = false;
+            }
+          }
+          // Set balance to 0, add to paid out, insert to ledger
+          if ($continue == true && $transaction->addTransaction($_SESSION['USERDATA']['id'], $dBalance, 'Debit_MP', NULL, $sCoinAddress)) {
+            $_SESSION['POPUP'][] = array('CONTENT' => 'Transaction completed', 'TYPE' => 'success');
+            $aMailData['email'] = $user->getUserEmail($user->getUserName($_SESSION['USERDATA']['id']));
+            $aMailData['amount'] = $dBalance;
+            $aMailData['subject'] = 'Manual Payout Completed';
+            $notification->sendNotification($_SESSION['USERDATA']['id'], 'manual_payout', $aMailData);
+          }
+        } else {
+          $_SESSION['POPUP'][] = array('CONTENT' => 'Unable to connect to litecoind RPC service', 'TYPE' => 'errormsg');
         }
-        // Set balance to 0, add to paid out, insert to ledger
-        if ($continue == true && $transaction->addTransaction($_SESSION['USERDATA']['id'], $dBalance, 'Debit_MP', NULL, $sCoinAddress)) {
-          $_SESSION['POPUP'][] = array('CONTENT' => 'Transaction completed', 'TYPE' => 'success');
-          $aMailData['email'] = $user->getUserEmail($user->getUserName($_SESSION['USERDATA']['id']));
-          $aMailData['amount'] = $dBalance;
-          $aMailData['subject'] = 'Manual Payout Completed';
-          $notification->sendNotification($_SESSION['USERDATA']['id'], 'manual_payout', $aMailData);
-      }
       } else {
-        $_SESSION['POPUP'][] = array('CONTENT' => 'Unable to connect to litecoind RPC service', 'TYPE' => 'errormsg');
+        $_SESSION['POPUP'][] = array('CONTENT' => 'Insufficient funds, you need more than 0.1 LTC to cover transaction fees', 'TYPE' => 'errormsg');
       }
-    } else {
-      $_SESSION['POPUP'][] = array('CONTENT' => 'Insufficient funds, you need more than 0.1 LTC to cover transaction fees', 'TYPE' => 'errormsg');
+      $setting->setValue('manual_payout_active', 0);
     }
     break;
 


### PR DESCRIPTION
- Mark manual payout active
- Run payout logics
- Reset manual payout

This ensures only one manual transaction can be run at a time.
If any users starts a manual payout others have to wait until the site
completed loading and finished the transaction process.

As long as we don't have too many users doing a manual payout at the
same time this should not be an issue. Best for users is using auto
payouts anyway.

This addresses #149
