### PR TITLE
Fixing column name in settings table

### DIFF
--- a/sql/issue_167_settings_upgrade.sql
+++ b/sql/issue_167_settings_upgrade.sql
@@ -1,0 +1,1 @@
+ALTER TABLE  `settings` CHANGE  `setting`  `name` VARCHAR( 255 ) CHARACTER SET utf8 COLLATE utf8_general_ci NOT NULL ;


### PR DESCRIPTION
- This will change the name in the settings table for old installations

Fixes #167
