### PR TITLE
Adding support for API currencies

### DIFF
--- a/public/include/config/global.inc.dist.php
+++ b/public/include/config/global.inc.dist.php
@@ -23,7 +23,8 @@ define('SALT', 'PLEASEMAKEMESOMETHINGRANDOM');
 $config = array(
   'price' => array(
     'url' =>     'https://btc-e.com/api/2',
-    'target' =>  '/ltc_usd/ticker'
+    'target' =>  '/ltc_usd/ticker',
+    'currency' => 'USD'             // Used in ministats template
   ),
   'ap_threshold' => array(
     'min' => 1,

--- a/public/include/smarty_globals.inc.php
+++ b/public/include/smarty_globals.inc.php
@@ -39,6 +39,7 @@ $aGlobal = array(
   'blockexplorer' => $config['blockexplorer'],
   'chaininfo' => $config['chaininfo'],
   'config' => array(
+    'price' => array( 'currency' => $config['price']['currency'] ),
     'targetdiff' => $config['difficulty'],
     'currency' => $config['currency'],
     'txfee' => $config['txfee'],

--- a/public/templates/mmcFE/global/header.tpl
+++ b/public/templates/mmcFE/global/header.tpl
@@ -4,7 +4,7 @@
           <div id="ministats">
             <table border="0">
               <tr>
-                <td><li>{$GLOBAL.config.currency}/usd: {$GLOBAL.price|default:"n/a"|number_format:"4"}&nbsp;&nbsp;&nbsp;&nbsp;</li></td>
+                <td><li>{$GLOBAL.config.currency}/{$GLOBAL.config.price.currency}: {$GLOBAL.price|default:"n/a"|number_format:"4"}&nbsp;&nbsp;&nbsp;&nbsp;</li></td>
                 <td><li>Pool Hashrate: {($GLOBAL.hashrate / 1000)|number_format:"3"} MH/s&nbsp;&nbsp;&nbsp;&nbsp;</li></td>
                 <td><li>Pool Sharerate: {$GLOBAL.sharerate|number_format:"2"} Shares/s&nbsp;&nbsp;&nbsp;&nbsp;</li></td>
                 <td><li>Pool Workers: {$GLOBAL.workers}&nbsp;&nbsp;&nbsp;&nbsp;</li></td>

--- a/public/templates/mmcFE/statistics/pool/contributors_hashrate.tpl
+++ b/public/templates/mmcFE/statistics/pool/contributors_hashrate.tpl
@@ -7,7 +7,7 @@
         <th align="left" scope="col">User Name</th>
         <th class="right" scope="col">KH/s</th>
         <th class="right">{$GLOBAL.config.currency}/Day</th>
-        <th class="right">USD/Day</th>
+        <th class="right">{$GLOBAL.config.price.currency}/Day</th>
       </tr>
     </thead>
     <tbody>


### PR DESCRIPTION
Since some altcoins are not listed with USD yet @vias79 suggested adding
different API target currencies. This commit will add the feature and
closes #201.
