### PR TITLE
Display error message to user on failed logins

### DIFF
--- a/public/include/classes/user.class.php
+++ b/public/include/classes/user.class.php
@@ -71,7 +71,7 @@ class User {
     $field = array('name' => 'token', 'type' => 's', 'value' => hash('sha256', $id.time().$this->salt));
     return $this->updateSingle($id, $field);
   }
-  private function setUserFailed($id, $value) {
+  public function setUserFailed($id, $value) {
     $field = array( 'name' => 'failed_logins', 'type' => 'i', 'value' => $value);
     return $this->updateSingle($id, $field);
   }
@@ -111,7 +111,6 @@ class User {
     }
     if ( $this->checkUserPassword($username, $password)) {
       $this->createSession($username);
-      $this->setUserFailed($this->getUserId($username), 0);
       $this->setUserIp($this->getUserId($username), $_SERVER['REMOTE_ADDR']);
       return true;
     }

--- a/public/include/pages/account/reset_failed.inc.php
+++ b/public/include/pages/account/reset_failed.inc.php
@@ -1,0 +1,12 @@
+<?php
+
+// Make sure we are called from index.php
+if (!defined('SECURITY')) die('Hacking attempt');
+
+if ($user->isAuthenticated()) {
+  // Reset failed login counter
+  $user->setUserFailed($_SESSION['USERDATA']['id'], 0);
+  header("Location: " . $_SERVER['HTTP_REFERER']);
+}
+
+?>

--- a/public/include/smarty_globals.inc.php
+++ b/public/include/smarty_globals.inc.php
@@ -76,6 +76,8 @@ if (@$_SESSION['USERDATA']['id']) {
   // Site-wide notifications, based on user events
   if ($aGlobal['userdata']['balance']['confirmed'] >= $config['ap_threshold']['max'])
     $_SESSION['POPUP'][] = array('CONTENT' => 'You have exceeded your accounts balance. Please transfer some ' . $config['currency'] . "!", 'TYPE' => 'errormsg');
+  if ($user->getUserFailed($_SESSION['USERDATA']['id']) > 0)
+    $_SESSION['POPUP'][] = array('CONTENT' => 'You have ' . $user->getUserFailed($_SESSION['USERDATA']['id']) . ' failed login attempts! <a href="?page=account&action=reset_failed">Reset Counter</a>', 'TYPE' => 'errormsg');
 }
 
 // Make it available in Smarty

--- a/public/index.php
+++ b/public/index.php
@@ -78,7 +78,7 @@ $smarty->assign("ACTION", $action);
 // Now with all loaded and processed, setup some globals we need for smarty templates
 require_once(INCLUDE_DIR . '/smarty_globals.inc.php');
 
-// Debguger 
+// Load debug information into template
 $debug->append("Loading debug information into template", 4);
 $smarty->assign('DebuggerInfo', $debug->getDebugInfo());
 


### PR DESCRIPTION
Warn a user with an error that there have been failed login attempts
for their account. Login errors can be cleared by clicking on the URL in
the message itself.

Fixes #240
