### PR TITLE
Fixing unauthenticated navigation for stats

### DIFF
--- a/public/templates/mmcFE/global/navigation.tpl
+++ b/public/templates/mmcFE/global/navigation.tpl
@@ -19,13 +19,17 @@
               </ul>
             </li>
             {/if}
+            {if $smarty.session.AUTHENTICATED|default}
             <li><a href="{$smarty.server.PHP_SELF}?page=statistics&action=pool">Statistics</a>
               <ul>
                 <li><a href="{$smarty.server.PHP_SELF}?page=statistics&action=pool">Pool Stats</a></li>
-                {if $smarty.session.AUTHENTICATED|default}<li><a href="{$smarty.server.PHP_SELF}?page=statistics&action=blocks">Block Stats</a></li>{/if}
-                {if $smarty.session.AUTHENTICATED|default}<li><a href="{$smarty.server.PHP_SELF}?page=statistics&action=graphs">Hashrate Graphs</a></li>{/if}
+                <li><a href="{$smarty.server.PHP_SELF}?page=statistics&action=blocks">Block Stats</a></li>
+                <li><a href="{$smarty.server.PHP_SELF}?page=statistics&action=graphs">Hashrate Graphs</a></li>
               </ul>
             </li>
+            {else}
+            <li><a href="{$smarty.server.PHP_SELF}?page=statistics">Statistics</a>
+            {/if}
             <li><a href="{$smarty.server.PHP_SELF}?page=gettingstarted">Getting Started</a></li>
             <li><a href="{$smarty.server.PHP_SELF}?page=support">Support</a></li>
             <li><a href="{$smarty.server.PHP_SELF}?page=about&action=pool">About</a>


### PR DESCRIPTION
Use different link to properly display pool statistics if not
authenticated.

Fixes #245
