### PR TITLE
Add number formatting in account transactions

### DIFF
--- a/public/templates/mmcFE/account/transactions/default.tpl
+++ b/public/templates/mmcFE/account/transactions/default.tpl
@@ -32,7 +32,7 @@
           <td>{$TRANSACTIONS[transaction].type}</td>
           <td>{$TRANSACTIONS[transaction].coin_address}</td>
           <td>{if $TRANSACTIONS[transaction].height == 0}n/a{else}{$TRANSACTIONS[transaction].height}{/if}</td>
-          <td><font color="{if $TRANSACTIONS[transaction].type == 'Credit' or $TRANSACTIONS[transaction].type == 'Credit_PPS' or $TRANSACTIONS[transaction].type == 'Bonus'}green{else}red{/if}">{$TRANSACTIONS[transaction].amount}</td>
+          <td><font color="{if $TRANSACTIONS[transaction].type == 'Credit' or $TRANSACTIONS[transaction].type == 'Credit_PPS' or $TRANSACTIONS[transaction].type == 'Bonus'}green{else}red{/if}">{$TRANSACTIONS[transaction].amount|number_format:"8"}</td>
         </tr>
         {/if}
 {/section}
@@ -72,7 +72,7 @@
           <td>{$TRANSACTIONS[transaction].type}</td>
           <td>{$TRANSACTIONS[transaction].coin_address}</td>
           <td>{if $TRANSACTIONS[transaction].height == 0}n/a{else}{$TRANSACTIONS[transaction].height}{/if}</td>
-          <td><font color="{if $TRANSACTIONS[transaction].type == 'Credit' or $TRANSACTIONS[transaction].type == 'Bonus'}green{else}red{/if}">{$TRANSACTIONS[transaction].amount}</td>
+          <td><font color="{if $TRANSACTIONS[transaction].type == 'Credit' or $TRANSACTIONS[transaction].type == 'Bonus'}green{else}red{/if}">{$TRANSACTIONS[transaction].amount|number_format:"8"}</td>
         </tr>
           {if $TRANSACTIONS[transaction].type == 'Credit' or $TRANSACTIONS[transaction].type == 'Bonus'}
             {assign var="credits" value="`$credits+$TRANSACTIONS[transaction].amount`"}
@@ -83,7 +83,7 @@
 {/section}
         <tr>
           <td colspan="5"><b>Unconfirmed Totals:</b></td>
-          <td><b>{$credits|default - $debits|default}</b></td>
+          <td><b>{($credits|default - $debits|default)|number_format:"8"}</b></td>
         </tr>
       </tbody>
     </table>
@@ -118,7 +118,7 @@
           <td>{$TRANSACTIONS[transaction].type}</td>
           <td>{$TRANSACTIONS[transaction].coin_address}</td>
           <td>{if $TRANSACTIONS[transaction].height == 0}n/a{else}{$TRANSACTIONS[transaction].height}{/if}</td>
-          <td><font color="{if $TRANSACTIONS[transaction].type == 'Orphan_Credit' or $TRANSACTIONS[transaction].type == 'Orphan_Bonus'}green{else}red{/if}">{$TRANSACTIONS[transaction].amount}</td>
+          <td><font color="{if $TRANSACTIONS[transaction].type == 'Orphan_Credit' or $TRANSACTIONS[transaction].type == 'Orphan_Bonus'}green{else}red{/if}">{$TRANSACTIONS[transaction].amount|number_format:"8"}</td>
         </tr>
           {if $TRANSACTIONS[transaction].type == 'Orphan_Credit' or $TRANSACTIONS[transaction].type == 'Orphan_Bonus'}
             {assign var="orphan_credits" value="`$orphan_credits+$TRANSACTIONS[transaction].amount`"}
@@ -129,7 +129,7 @@
 {/section}
         <tr>
           <td colspan="5"><b>Orphaned Totals:</b></td>
-          <td><b>{$orphan_credits|default - $orphan_debits|default}</b></td>
+          <td><b>{($orphan_credits|default - $orphan_debits|default)|number_format:"8"}</b></td>
         </tr>
       </tbody>
     </table>


### PR DESCRIPTION
This should fix #282 where numbers are displayed in scientific notation.
