### PR TITLE
Enable or Disable maintenance and registrations

### DIFF
--- a/public/include/autoloader.inc.php
+++ b/public/include/autoloader.inc.php
@@ -22,12 +22,12 @@ require_once(INCLUDE_DIR . '/smarty.inc.php');
 // Load classes that need the above as dependencies
 require_once(CLASS_DIR . '/base.class.php');
 require_once(CLASS_DIR . '/block.class.php');
+require_once(CLASS_DIR . '/setting.class.php');
 require_once(CLASS_DIR . '/user.class.php');
 require_once(CLASS_DIR . '/share.class.php');
 require_once(CLASS_DIR . '/worker.class.php');
 require_once(CLASS_DIR . '/statistics.class.php');
 require_once(CLASS_DIR . '/transaction.class.php');
-require_once(CLASS_DIR . '/setting.class.php');
 require_once(CLASS_DIR . '/mail.class.php');
 require_once(CLASS_DIR . '/notification.class.php');
 require_once(CLASS_DIR . '/news.class.php');

--- a/public/include/classes/user.class.php
+++ b/public/include/classes/user.class.php
@@ -372,12 +372,12 @@ class User {
    * @param none
    * @return true
    **/
-  public function logoutUser() {
+  public function logoutUser($redirect="index.php") {
     $this->debug->append("STA " . __METHOD__, 4);
     session_destroy();
     session_regenerate_id(true);
     // Enforce a page reload
-    header("Location: index.php");
+    header("Location: $redirect");
   }
 
   /**
@@ -555,8 +555,10 @@ class User {
    **/
   public function isAuthenticated() {
     $this->debug->append("STA " . __METHOD__, 4);
-    if (@$_SESSION['AUTHENTICATED'] == true && ! $this->isLocked($_SESSION['USERDATA']['id']) && $this->getUserIp($_SESSION['USERDATA']['id']) == $_SERVER['REMOTE_ADDR'])
-      return true;
+    if (@$_SESSION['AUTHENTICATED'] == true &&
+        !$this->isLocked($_SESSION['USERDATA']['id']) &&
+        $this->getUserIp($_SESSION['USERDATA']['id']) == $_SERVER['REMOTE_ADDR']
+      ) return true;
     // Catchall
     $this->logoutUser();
     return false;

--- a/public/include/pages/admin/settings.inc.php
+++ b/public/include/pages/admin/settings.inc.php
@@ -1,0 +1,25 @@
+<?php
+
+// Make sure we are called from index.php
+if (!defined('SECURITY')) die('Hacking attempt');
+
+// Check user to ensure they are admin
+if (!$user->isAuthenticated() || !$user->isAdmin($_SESSION['USERDATA']['id'])) {
+  header("HTTP/1.1 404 Page not found");
+  die("404 Page not found");
+}
+
+if ($_REQUEST['do'] == 'save' && !empty($_REQUEST['data'])) {
+  foreach($_REQUEST['data'] as $var => $value) {
+    $setting->setValue($var, $value);
+  }
+  $_SESSION['POPUP'][] = array('CONTENT' => 'Settings updated');
+}
+
+// Fetch settings to propagate to template
+$smarty->assign("MAINTENANCE", $setting->getValue('maintenance'));
+$smarty->assign("REGISTRATION", $setting->getValue('registration'));
+
+// Tempalte specifics
+$smarty->assign("CONTENT", "default.tpl");
+?>

--- a/public/include/pages/login.inc.php
+++ b/public/include/pages/login.inc.php
@@ -1,14 +1,16 @@
 <?php
 
 // Make sure we are called from index.php
-if (!defined('SECURITY'))
-    die('Hacking attempt');
+if (!defined('SECURITY')) die('Hacking attempt');
 
-if ( $user->checkLogin($_POST['username'],$_POST['password']) ) {
+if ($setting->getValue('maintenance') && !$user->isAdmin($user->getUserId($_POST['username']))) {
+  $_SESSION['POPUP'][] = array('CONTENT' => 'You are not allowed to login during maintenace.', 'TYPE' => 'info');
+} else if ($user->checkLogin($_POST['username'],$_POST['password']) ) {
   header('Location: index.php?page=home');
 } else if (@$_POST['username'] && @$_POST['password']) {
   $_SESSION['POPUP'][] = array('CONTENT' => 'Unable to login: '. $user->getError(), 'TYPE' => 'errormsg');
 }
 
+// Load login template
 $smarty->assign('CONTENT', 'default.tpl');
 ?>

--- a/public/include/pages/register.inc.php
+++ b/public/include/pages/register.inc.php
@@ -3,7 +3,7 @@
 // Make sure we are called from index.php
 if (!defined('SECURITY')) die('Hacking attempt');
 
-if (!$config['website']['registration']) {
+if (!$config['website']['registration'] || !$setting->getValue('registration')) {
   $_SESSION['POPUP'][] = array('CONTENT' => 'Account registration is currently disabled. Please try again later.', 'TYPE' => 'errormsg');
   $smarty->assign("CONTENT", "disabled.tpl");
 } else {

--- a/public/include/pages/register/register.inc.php
+++ b/public/include/pages/register/register.inc.php
@@ -17,9 +17,9 @@ if ($config['recaptcha']['enabled']) {
 if($config['recaptcha']['enabled'] && $_POST["recaptcha_response_field"] && $_POST["recaptcha_response_field"]!=''){
   if ($rsp->is_valid) {
     $smarty->assign("RECAPTCHA", recaptcha_get_html($config['recaptcha']['public_key']));
-    if (!$config['website']['registration']) {
+    if (!$config['website']['registration'] || !$setting->getValue('registration')) {
       $_SESSION['POPUP'][] = array('CONTENT' => 'Account registration is currently disabled. Please try again later.', 'TYPE' => 'errormsg');
-    } else if ($user->register($_POST['username'], $_POST['password1'], $_POST['password2'], $_POST['pin'], $_POST['email1'], $_POST['email2']) && $config['website']['registration']) {
+    } else if ($user->register($_POST['username'], $_POST['password1'], $_POST['password2'], $_POST['pin'], $_POST['email1'], $_POST['email2']) && ($config['website']['registration'] || $setting->getValue('registration'))) {
       $_SESSION['POPUP'][] = array('CONTENT' => 'Account created, please login');
     } else {
       $_SESSION['POPUP'][] = array('CONTENT' => 'Unable to create account: ' . $user->getError(), 'TYPE' => 'errormsg');
@@ -34,7 +34,7 @@ if($config['recaptcha']['enabled'] && $_POST["recaptcha_response_field"] && $_PO
   $_SESSION['POPUP'][] = array('CONTENT' => 'Empty Captcha, please try again.', 'TYPE' => 'errormsg');
 // Captcha disabled
 } else {
-  if (!$config['website']['registration']) {
+  if (!$config['website']['registration'] || !$setting->getValue('registration')) {
     $_SESSION['POPUP'][] = array('CONTENT' => 'Account registration is currently disabled. Please try again later.', 'TYPE' => 'errormsg');
   } else if ($user->register($_POST['username'], $_POST['password1'], $_POST['password2'], $_POST['pin'], $_POST['email1'], $_POST['email2']) && $config['website']['registration']) {
     $_SESSION['POPUP'][] = array('CONTENT' => 'Account created, please login');

--- a/public/include/smarty_globals.inc.php
+++ b/public/include/smarty_globals.inc.php
@@ -80,6 +80,9 @@ if (@$_SESSION['USERDATA']['id']) {
     $_SESSION['POPUP'][] = array('CONTENT' => 'You have ' . $user->getUserFailed($_SESSION['USERDATA']['id']) . ' failed login attempts! <a href="?page=account&action=reset_failed">Reset Counter</a>', 'TYPE' => 'errormsg');
 }
 
+if ($setting->getValue('maintenance'))
+  $_SESSION['POPUP'][] = array('CONTENT' => 'This pool is currently in maintenance mode.', 'TYPE' => 'warning');
+
 // Make it available in Smarty
 $smarty->assign('PATH', 'site_assets/' . THEME);
 $smarty->assign('GLOBAL', $aGlobal);

--- a/public/templates/mmcFE/admin/settings/default.tpl
+++ b/public/templates/mmcFE/admin/settings/default.tpl
@@ -1,0 +1,27 @@
+{include file="global/block_header.tpl" BLOCK_HEADER="Admin Settings"}
+<form method="POST">
+  <input type="hidden" name="page" value="{$smarty.request.page}" />
+  <input type="hidden" name="action" value="{$smarty.request.action}" />
+  <input type="hidden" name="do" value="save" />
+  <table>
+    <thead>
+      <th class="left">Setting</th>
+      <th class="center">Help</th>
+      <th>Value</th>
+    </thead>
+    <tbody>
+      <tr>
+        <td class="left">Maintenance Mode</td>
+        <td class="center"><span id='tt'><img src='{$PATH}/images/questionmark.png' height='15px' width='15px' title='Enable Maintenance Mode for mmcfe-ng. Only admins can login.'></span></td>
+        <td><select name="data[maintenance]"><option value="1">Yes</option><option value="0"{if !$MAINTENANCE} selected{/if}>No</option></select></td>
+      </tr>
+      <tr>
+        <td class="left">User Registration</td>
+        <td class="center"><span id='tt'><img src='{$PATH}/images/questionmark.png' height='15px' width='15px' title='Enable or disable new account registration. Can also be done via configuration option.'></span></td>
+        <td><select name="data[registration]"><option value="1">Yes</option><option value="0"{if !$REGISTRATION} selected{/if}>No</option></select></td>
+      </tr>
+      <tr><td class="center" colspan="3"><input type="submit" value="Save" class="submit small" /></td></tr>
+    </tbody>
+  </table>
+</form>
+{include file="global/block_footer.tpl"}

--- a/public/templates/mmcFE/global/navigation.tpl
+++ b/public/templates/mmcFE/global/navigation.tpl
@@ -16,6 +16,7 @@
                 <li><a href="{$smarty.server.PHP_SELF}?page=admin&action=user">User Info</a></li>
                 <li><a href="{$smarty.server.PHP_SELF}?page=admin&action=wallet">Wallet Info</a></li>
                 <li><a href="{$smarty.server.PHP_SELF}?page=admin&action=transactions">Transactions</a></li>
+                <li><a href="{$smarty.server.PHP_SELF}?page=admin&action=settings">Settings</a></li>
                 <li><a href="{$smarty.server.PHP_SELF}?page=admin&action=news">News</a></li>
               </ul>
             </li>


### PR DESCRIPTION
This will allow any admin to enable or disable a pool maintenance mode.
Regular users that are still logged in will not be kicked out (yet). New
users that are trying to login and are not admins will be denied access.

Also added registration option to Admin Settings via WebUI. You can now
disable new accounts via web option or configuration setting.

Fixes #259 but also adds an additional feature.
