### PR TITLE
Properly display estimates on 0 valid shares

### DIFF
--- a/public/include/smarty_globals.inc.php
+++ b/public/include/smarty_globals.inc.php
@@ -66,10 +66,17 @@ if (@$_SESSION['USERDATA']['id']) {
     break;
   default:
     // Some estimations
-    $aGlobal['userdata']['est_block'] = round(( (int)$aGlobal['userdata']['shares']['valid'] / (int)$aRoundShares['valid'] ) * (int)$config['reward'], 3);
-    $aGlobal['userdata']['est_fee'] = round(($config['fees'] / 100) * $aGlobal['userdata']['est_block'], 3);
-    $aGlobal['userdata']['est_donation'] = round((( $aGlobal['userdata']['donate_percent'] / 100) * ($aGlobal['userdata']['est_block'] - $aGlobal['userdata']['est_fee'])), 3);
-    $aGlobal['userdata']['est_payout'] = round($aGlobal['userdata']['est_block'] - $aGlobal['userdata']['est_donation'] - $aGlobal['userdata']['est_fee'], 3);
+    if (@$aRoundShares['valid'] > 0) {
+      $aGlobal['userdata']['est_block'] = round(( (int)$aGlobal['userdata']['shares']['valid'] / (int)$aRoundShares['valid'] ) * (int)$config['reward'], 3);
+      $aGlobal['userdata']['est_fee'] = round(($config['fees'] / 100) * $aGlobal['userdata']['est_block'], 3);
+      $aGlobal['userdata']['est_donation'] = round((( $aGlobal['userdata']['donate_percent'] / 100) * ($aGlobal['userdata']['est_block'] - $aGlobal['userdata']['est_fee'])), 3);
+      $aGlobal['userdata']['est_payout'] = round($aGlobal['userdata']['est_block'] - $aGlobal['userdata']['est_donation'] - $aGlobal['userdata']['est_fee'], 3);
+    } else {
+      $aGlobal['userdata']['est_block'] = 0;
+      $aGlobal['userdata']['est_fee'] = 0;
+      $aGlobal['userdata']['est_donation'] = 0;
+      $aGlobal['userdata']['est_payout'] = 0;
+    }
     break;
   }
 


### PR DESCRIPTION
If pool has no valid shares, display 0 as the estimated payout. This
will avoid a PHP Warning devision by zero.

Fixes #296, do not run into Divide by zero error when missing round
shares
