### PR TITLE
Adding reference for API documentation

### DIFF
--- a/public/include/pages/about/api.inc.php
+++ b/public/include/pages/about/api.inc.php
@@ -1,0 +1,8 @@
+<?php
+
+// Make sure we are called from index.php
+if (!defined('SECURITY')) die('Hacking attempt');
+
+// Tempalte specifics
+$smarty->assign("CONTENT", "default.tpl");
+?>

--- a/public/templates/mmcFE/about/api/default.tpl
+++ b/public/templates/mmcFE/about/api/default.tpl
@@ -1,0 +1,3 @@
+{include file="global/block_header.tpl" BLOCK_HEADER="API Reference"}
+<p>Please head over to the <a href="https://github.com/TheSerapher/php-mmcfe-ng/wiki/API-Reference">official documentation</a> to learn about the API featured in <b>mmcfe-ng</b>.</p>
+{include file="global/block_footer.tpl"}

--- a/public/templates/mmcFE/global/navigation.tpl
+++ b/public/templates/mmcFE/global/navigation.tpl
@@ -37,6 +37,7 @@
             <li><a href="{$smarty.server.PHP_SELF}?page=about&action=pool">About</a>
               <ul>
                 <li><a href="{$smarty.server.PHP_SELF}?page=about&action=pool">This Pool</a></li>
+                <li><a href="{$smarty.server.PHP_SELF}?page=about&action=api">API Reference</a></li>
                 <li><a href="{$smarty.server.PHP_SELF}?page=about&action=donors">Pool Donors</a></li>
               </ul>
             </li>


### PR DESCRIPTION
This is a simple version since API documentation is already documented
on the GitHub Wiki.

Fixes #323
