### PR TITLE
Fixing PHP Warnings in Registration page

### DIFF
--- a/public/include/classes/user.class.php
+++ b/public/include/classes/user.class.php
@@ -449,7 +449,7 @@ class User {
       $this->setErrorMessage( 'Invalid PIN' );
       return false;
     }
-    $apikey = hash("sha256",$username.$salt);
+    $apikey = hash("sha256",$username.$this->salt);
     if ($this->mysqli->query("SELECT id FROM $this->table LIMIT 1")->num_rows > 0) {
       $stmt = $this->mysqli->prepare("
         INSERT INTO $this->table (username, pass, email, pin, api_key)

--- a/public/templates/mmcFE/register/default.tpl
+++ b/public/templates/mmcFE/register/default.tpl
@@ -10,7 +10,7 @@
       <tr><td>Email:</td><td><input type="text" name="email1" class="text small" value="{$smarty.post.email1|escape|default:""}" size="15" required></td></tr>
       <tr><td>Email Repeat:</td><td><input type="text" class="text small" name="email2" value="{$smarty.post.email2|escape|default:""}" size="15" required></td></tr>
       <tr><td>PIN:</td><td><input type="password" class="text pin" name="pin" value="" size="4" maxlength="4"><font size="1"> (4 digit number. <b>Remember this pin!</b>)</font></td></tr>
-      <tr><td colspan="2">{nocache}{$RECAPTCHA}{/nocache}</td></tr>
+      <tr><td colspan="2">{nocache}{$RECAPTCHA|default:""}{/nocache}</td></tr>
       <tr><td class="center"><input type="submit" class="submit small" value="Register"></td><td></td></tr>
     </tbody>
   </table>


### PR DESCRIPTION
- Fix API Key generation not using SALT when creating hash
  - This should not affect existing API keys since hashes are compared
- Fix PHP Warning for RECAPTCHA if disabled

Fixes #328 and #329 
