### PR TITLE
Show nethash rate in MHash/s not GHash/s

### DIFF
--- a/public/templates/mmcFE/global/header.tpl
+++ b/public/templates/mmcFE/global/header.tpl
@@ -5,7 +5,7 @@
             <table border="0">
               <tr>
                 {if $GLOBAL.config.price.currency}<td><li>{$GLOBAL.config.currency}/{$GLOBAL.config.price.currency}: {$GLOBAL.price|default:"n/a"|number_format:"4"}&nbsp;&nbsp;&nbsp;&nbsp;</li></td>{/if}
-                <td><li>Network Hashrate: {($GLOBAL.nethashrate / 1000 / 1000 / 1000)|default:"0"|number_format:"3"} GH/s&nbsp;&nbsp;&nbsp;&nbsp;</li></td>
+                <td><li>Network Hashrate: {($GLOBAL.nethashrate / 1000 / 1000 )|default:"0"|number_format:"3"} MH/s&nbsp;&nbsp;&nbsp;&nbsp;</li></td>
                 <td><li>Pool Hashrate: {($GLOBAL.hashrate / 1000)|number_format:"3"} MH/s&nbsp;&nbsp;&nbsp;&nbsp;</li></td>
                 <td><li>Pool Sharerate: {$GLOBAL.sharerate|number_format:"2"} Shares/s&nbsp;&nbsp;&nbsp;&nbsp;</li></td>
                 <td><li>Pool Workers: {$GLOBAL.workers}&nbsp;&nbsp;&nbsp;&nbsp;</li></td>


### PR DESCRIPTION
- Easier to compare directly with pool hashrate
- Better display format for low nethash rate coins

Fixes #331
