### PR TITLE
Adding dynamic block value support in PPS

### DIFF
--- a/cronjobs/findblock.php
+++ b/cronjobs/findblock.php
@@ -63,6 +63,7 @@ if (empty($aTransactions['transactions'])) {
         verbose("Failed" . "\n");
       }
     }
+    exit;
   }
 }
 

--- a/cronjobs/pps_payout.php
+++ b/cronjobs/pps_payout.php
@@ -40,7 +40,16 @@ if ( $bitcoin->can_connect() === true ){
 }
 
 // Value per share calculation
-$pps_value = number_format(round(50 / (pow(2,32) * $dDifficulty) * pow(2, $config['difficulty']), 12) ,12);
+if ($config['reward_type'] != 'block') {
+$pps_value = number_format(round($config['reward'] / (pow(2,32) * $dDifficulty) * pow(2, $config['difficulty']), 12) ,12);
+} else {
+  // Try to find the last block value and use that for future payouts, revert to fixed reward if none found
+  if ($aLastBlock = $block->getLast()) {
+    $pps_value = number_format(round($aLastBlock['amount'] / (pow(2,32) * $dDifficulty) * pow(2, $config['difficulty']), 12) ,12);
+  } else {
+    $pps_value = number_format(round($config['reward'] / (pow(2,32) * $dDifficulty) * pow(2, $config['difficulty']), 12) ,12);
+  }
+}
 
 // Find our last share accounted and last inserted share for PPS calculations
 $iPreviousShareId = $setting->getValue('pps_last_share_id');

--- a/public/include/config/global.inc.dist.php
+++ b/public/include/config/global.inc.dist.php
@@ -177,12 +177,33 @@ $config['difficulty'] = 20;
 /**
  * This defines how rewards are paid to users.
  *
+ * Explanation:
+ *
+ *  Proportional Payout System
+ *   When running a pool on fixed mode, each block will be paid
+ *   out as defined in `reward`. If you wish to pass transaction
+ *   fees inside discovered blocks on to user, set this to `block`.
+ *   This is really helpful for altcoins with dynamic block values!
+ *
+ *  PPS Payout System
+ *   If set to `fixed`, all PPS values are based on the `reward` setting.
+ *   If you set it to `block` you will calculate the current round based
+ *   on the previous block value. The idea is to pass the block of the
+ *   last round on to the users. If no previous block is found, PPS value
+ *   will fall back to the fixed value set in `reward`. Ensure you don't
+ *   overpay users in the first round!
+ *
  * Available options:
+ *  reward_type:
  *   fixed : Fixed value according to `reward` setting
  *   block : Dynamic value based on block amount
+ *  reward:
+ *   float value : Any value of your choice but should reflect base block values
  *
  * Default:
- *   fixed
+ *   reward_type  = `fixed`
+ *   reward       = 50
+ *   
  **/
 $config['reward_type'] = 'fixed';
 $config['reward'] = 50;

--- a/public/include/smarty_globals.inc.php
+++ b/public/include/smarty_globals.inc.php
@@ -32,7 +32,6 @@ $aGlobal = array(
   'websitename' => $config['website']['name'],
   'hashrate' => $iCurrentPoolHashrate,
   'sharerate' => $iCurrentPoolShareRate,
-  'ppsvalue' => number_format(round(50 / (pow(2,32) * $dDifficulty) * pow(2, $config['difficulty']), 12) ,12),
   'workers' => $iCurrentActiveWorkers,
   'roundshares' => $aRoundShares,
   'fees' => $config['fees'],
@@ -54,6 +53,18 @@ $aGlobal = array(
     )
   )
 );
+
+// Special calculations for PPS Values based on reward_type setting and/or available blocks
+if ($config['reward_type'] != 'block') {
+  $aGlobal['ppsvalue'] = number_format(round(50 / (pow(2,32) * $dDifficulty) * pow(2, $config['difficulty']), 12) ,12);
+} else {
+  // Try to find the last block value and use that for future payouts, revert to fixed reward if none found
+  if ($aLastBlock = $block->getLast()) {
+    $aGlobal['ppsvalue'] = number_format(round($aLastBlock['amount'] / (pow(2,32) * $dDifficulty) * pow(2, $config['difficulty']), 12) ,12);
+  } else {
+    $aGlobal['ppsvalue'] = number_format(round($config['reward'] / (pow(2,32) * $dDifficulty) * pow(2, $config['difficulty']), 12) ,12);
+  }
+}
 
 // We don't want these session infos cached
 if (@$_SESSION['USERDATA']['id']) {


### PR DESCRIPTION
This will add the block reward typw to PPS systems. Prior to this, each
PPS value was hard coded to 50. Not only are other coins not based on
this but changing it would require code. Changed it that
- Default for fixed type is config reward
- Default for block type is **previous** blocks amount
  - Fallback for first round is the fixed reward value

See in-line documentation of dist configuration. This should help new
pool owners to get setup and clarify things.

Fixes #308
