### PR TITLE
Fix PHP Warnings on Password Reset page

### DIFF
--- a/public/include/classes/user.class.php
+++ b/public/include/classes/user.class.php
@@ -517,6 +517,10 @@ class User {
   public function resetPassword($username, $smarty) {
     $this->debug->append("STA " . __METHOD__, 4);
     // Fetch the users mail address
+    if (empty($username)) {
+      $this->serErrorMessage("Username must not be empty");
+      return false;
+    }
     if (!$email = $this->getUserEmail($username)) {
       $this->setErrorMessage("Unable to find a mail address for user $username");
       return false;

--- a/public/templates/mmcFE/password/default.tpl
+++ b/public/templates/mmcFE/password/default.tpl
@@ -3,6 +3,6 @@
 <input type="hidden" name="page" value="password">
 <input type="hidden" name="action" value="reset">
   <p>If you have an email set for your account, enter your username to get your password reset</p>
-  <p><input type="text" value="{$smarty.post.username}" name="username"><input class="submit small" type="submit" value="Reset"></p>
+  <p><input type="text" value="{$smarty.post.username|default:""}" name="username" required><input class="submit small" type="submit" value="Reset"></p>
 </form>
 {include file="global/block_footer.tpl"}


### PR DESCRIPTION
- Added HTML5 required to username field
- Added empty string check to resetPassword method

Fixes #348
