### PR TITLE
Skip bogus upstream shares

### DIFF
--- a/cronjobs/findblock.php
+++ b/cronjobs/findblock.php
@@ -77,7 +77,7 @@ if (empty($aAllBlocks)) {
   foreach ($aAllBlocks as $iIndex => $aBlock) {
     if (empty($aBlock['share_id'])) {
       // Fetch this blocks upstream ID
-      if ($share->setUpstream($block->getLastUpstreamId())) {
+      if ($share->setUpstream($block->getLastUpstreamId(), $aBlock['time'])) {
         $iCurrentUpstreamId = $share->getUpstreamId();
         $iAccountId = $user->getUserId($share->getUpstreamFinder());
       } else {
@@ -85,6 +85,7 @@ if (empty($aAllBlocks)) {
         verbose($share->getError() . "\n");
         exit;
       }
+
       // Fetch share information
       if (!$iPreviousShareId = $block->getLastShareId()) {
         $iPreviousShareId = 0;

--- a/public/include/classes/share.class.php
+++ b/public/include/classes/share.class.php
@@ -177,15 +177,16 @@ class Share {
    * @param last int Skips all shares up to last to find new share
    * @return bool
    **/
-  public function setUpstream($last=0) {
+  public function setUpstream($last=0, $time=0) {
     $stmt = $this->mysqli->prepare("
       SELECT
       SUBSTRING_INDEX( `username` , '.', 1 ) AS account, id
       FROM $this->table
       WHERE upstream_result = 'Y'
       AND id > ?
+      AND UNIX_TIMESTAMP(time) >= ?
       ORDER BY id ASC LIMIT 1");
-    if ($this->checkStmt($stmt) && $stmt->bind_param('i', $last) && $stmt->execute() && $result = $stmt->get_result()) {
+    if ($this->checkStmt($stmt) && $stmt->bind_param('ii', $last, $time) && $stmt->execute() && $result = $stmt->get_result()) {
       $this->oUpstream = $result->fetch_object();
       if (!empty($this->oUpstream->account) && is_int($this->oUpstream->id))
         return true;


### PR DESCRIPTION
This will fix an issue with blocks being assigned upstream shares that
are marked as valid but are not the actual solution for a block.

Only shares inserted when or after the block timestamp are now looked
at. This will ensure other shares inserted earlier and marked as
upstream valid are skipped.

This will not fix edge cases where many shares are inserted at the same
time and are all in the same timeframe of the block. Then the first
valid share in that time is used. We limit to exactly one result, so not
more than one share can ever be found.

This worked fine on a testnet with a number of blocks found and false
shares inserted by hand.

Fixes #352
