### PR TITLE
share counts off by one because BETWEEN is inclusive of the last_share_id

### DIFF
--- a/public/include/classes/share.class.php
+++ b/public/include/classes/share.class.php
@@ -70,7 +70,7 @@ class Share {
       count(id) as total
       FROM $this->table
       WHERE our_result = 'Y'
-      AND id BETWEEN ? AND ?
+      AND id > ? AND id <= ?
       ");
     if ($this->checkStmt($stmt)) {
       $stmt->bind_param('ii', $previous_upstream, $current_upstream);


### PR DESCRIPTION
Changed from BETWEEN last_share_id and current to > last_share_id and <= current_share_id
