### PR TITLE
Remove link on mobile if chaininfo empty

### DIFF
--- a/public/include/config/global.inc.dist.php
+++ b/public/include/config/global.inc.dist.php
@@ -164,6 +164,7 @@ $config['archive_shares'] = true;
 $config['blockexplorer'] = 'http://explorer.litecoin.net/search?q=';
 
 // Link to blockchain information, used for difficulty link, default: `http://allchains.info`
+// If empty, the difficulty link to the chain information will be removed
 $config['chaininfo'] = 'http://allchains.info';
 
 // Pool fees applied to users in percent, default: 0 (disabled)

--- a/public/templates/mobile/statistics/pool/authenticated.tpl
+++ b/public/templates/mobile/statistics/pool/authenticated.tpl
@@ -32,10 +32,12 @@
       <td class="leftheader">Last Block Found</td>
       <td><a href="{$GLOBAL.blockexplorer}{$LASTBLOCK}" target="_new">{$LASTBLOCK|default:"0"}</a></td>
     </tr>
+    {if $GLOBAL.chaininfo}
     <tr>
       <td class="leftheader">Current Difficulty</td>
       <td><a href="{$GLOBAL.chaininfo}" target="_new"><font size="2">{$DIFFICULTY}</font></a></td>
     </tr>
+    {/if}
     <tr>
       <td class="leftheader">Est. Avg. Time per Round</td>
       <td>{$ESTTIME|seconds_to_words}</td>


### PR DESCRIPTION
- Remove URL from Difficulty on stats page if chaininfo is empty
- Added note to global dist configuration file

Fixes #336
