### PR TITLE
Adding shares archive table back in for hash calcs

### DIFF
--- a/public/include/classes/statistics.class.php
+++ b/public/include/classes/statistics.class.php
@@ -99,8 +99,19 @@ class Statistics {
     $this->debug->append("STA " . __METHOD__, 4);
     if ($this->getGetCache() && $data = $this->memcache->get(__FUNCTION__)) return $data;
     $stmt = $this->mysqli->prepare("
-      SELECT ROUND(COUNT(id) * POW(2, " . $this->config['difficulty'] . ")/600/1000) AS hashrate FROM " . $this->share->getTableName() . " WHERE time > DATE_SUB(now(), INTERVAL 10 MINUTE)
-    ");
+      SELECT
+      (
+        (
+          SELECT ROUND(COUNT(id) * POW(2, " . $this->config['difficulty'] . ")/600/1000) AS hashrate
+          FROM " . $this->share->getTableName() . "
+          WHERE time > DATE_SUB(now(), INTERVAL 10 MINUTE)
+        ) + (
+          SELECT ROUND(COUNT(id) * POW(2, " . $this->config['difficulty'] . ")/600/1000) AS hashrate
+          FROM " . $this->share->getArchiveTableName() . "
+          WHERE time > DATE_SUB(now(), INTERVAL 10 MINUTE)
+        )
+      ) AS hashrate
+      FROM DUAL");
     // Catchall
     if ($this->checkStmt($stmt) && $stmt->execute() && $result = $stmt->get_result() ) return $this->memcache->setCache(__FUNCTION__, $result->fetch_object()->hashrate);
     $this->debug->append("Failed to get hashrate: " . $this->mysqli->error);
@@ -116,8 +127,9 @@ class Statistics {
     $this->debug->append("STA " . __METHOD__, 4);
     if ($data = $this->memcache->get(__FUNCTION__)) return $data;
     $stmt = $this->mysqli->prepare("
-      SELECT ROUND(COUNT(id) / 600, 2) AS sharerate FROM " . $this->share->getTableName() . " WHERE time > DATE_SUB(now(), INTERVAL 10 MINUTE)
-    ");
+      SELECT ROUND(COUNT(id) / 600, 2) AS sharerate
+      FROM " . $this->share->getTableName() . "
+      WHERE time > DATE_SUB(now(), INTERVAL 10 MINUTE)");
     if ($this->checkStmt($stmt) && $stmt->execute() && $result = $stmt->get_result() ) return $this->memcache->setCache(__FUNCTION__, $result->fetch_object()->sharerate);
     // Catchall
     $this->debug->append("Failed to fetch share rate: " . $this->mysqli->error);
@@ -161,9 +173,8 @@ class Statistics {
           u.id AS id,
           u.username AS username
       FROM " . $this->share->getTableName() . " AS s,
-             " . $this->user->getTableName() . " AS u
-      WHERE
-        u.username = SUBSTRING_INDEX( s.username, '.', 1 )
+           " . $this->user->getTableName() . " AS u
+      WHERE u.username = SUBSTRING_INDEX( s.username, '.', 1 )
         AND UNIX_TIMESTAMP(s.time) >IFNULL((SELECT MAX(b.time) FROM " . $this->block->getTableName() . " AS b),0)
       GROUP BY u.id");
     if ($stmt && $stmt->execute() && $result = $stmt->get_result())
@@ -186,7 +197,7 @@ class Statistics {
         SUM(IF(our_result='Y', 1, 0)) AS valid,
         SUM(IF(our_result='N', 1, 0)) AS invalid
       FROM " . $this->share->getTableName() . " AS s,
-             " . $this->user->getTableName() . " AS u
+           " . $this->user->getTableName() . " AS u
       WHERE
         u.username = SUBSTRING_INDEX( s.username, '.', 1 )
         AND UNIX_TIMESTAMP(s.time) >IFNULL((SELECT MAX(b.time) FROM " . $this->block->getTableName() . " AS b),0)
@@ -236,13 +247,24 @@ class Statistics {
     $this->debug->append("STA " . __METHOD__, 4);
     if ($data = $this->memcache->get(__FUNCTION__ . $account_id)) return $data;
     $stmt = $this->mysqli->prepare("
-      SELECT ROUND(COUNT(s.id) * POW(2, " . $this->config['difficulty'] . ")/600/1000) AS hashrate
-      FROM " . $this->share->getTableName() . " AS s,
-           " . $this->user->getTableName() . " AS u
-      WHERE u.username = SUBSTRING_INDEX( s.username, '.', 1 )
-        AND s.time > DATE_SUB(now(), INTERVAL 10 MINUTE)
-        AND u.id = ?");
-    if ($this->checkStmt($stmt) && $stmt->bind_param("i", $account_id) && $stmt->execute() && $result = $stmt->get_result() )
+      SELECT
+        (
+          SELECT ROUND(COUNT(s.id) * POW(2, " . $this->config['difficulty'] . ") / 600 / 1000) AS hashrate
+          FROM " . $this->share->getTableName() . " AS s,
+               " . $this->user->getTableName() . " AS u
+          WHERE u.username = SUBSTRING_INDEX( s.username, '.', 1 )
+            AND s.time > DATE_SUB(now(), INTERVAL 10 MINUTE)
+            AND u.id = ?
+        ) + (
+          SELECT ROUND(COUNT(s.id) * POW(2, " . $this->config['difficulty'] . ") / 600 / 1000) AS hashrate
+          FROM " . $this->share->getArchiveTableName() . " AS s,
+               " . $this->user->getTableName() . " AS u
+          WHERE u.username = SUBSTRING_INDEX( s.username, '.', 1 )
+            AND s.time > DATE_SUB(now(), INTERVAL 10 MINUTE)
+            AND u.id = ?
+        ) AS hashrate
+      FROM DUAL");
+    if ($this->checkStmt($stmt) && $stmt->bind_param("ii", $account_id, $account_id) && $stmt->execute() && $result = $stmt->get_result() )
       return $this->memcache->setCache(__FUNCTION__ . $account_id, $result->fetch_object()->hashrate);
     // Catchall
     $this->debug->append("Failed to fetch hashrate: " . $this->mysqli->error);
@@ -306,8 +328,8 @@ class Statistics {
     case 'shares':
       $stmt = $this->mysqli->prepare("
         SELECT
-            COUNT(id) AS shares,
-            SUBSTRING_INDEX( username, '.', 1 ) AS account
+          COUNT(id) AS shares,
+          SUBSTRING_INDEX( username, '.', 1 ) AS account
         FROM " . $this->share->getTableName() . "
         WHERE our_result = 'Y'
         GROUP BY account
@@ -324,9 +346,12 @@ class Statistics {
         SELECT
           ROUND(COUNT(id) * POW(2," . $this->config['difficulty'] . ")/600/1000,2) AS hashrate,
           SUBSTRING_INDEX( username, '.', 1 ) AS account
-        FROM " . $this->share->getTableName() . "
-        WHERE time > DATE_SUB(now(), INTERVAL 10 MINUTE)
-        AND our_result = 'Y'
+        FROM
+        (
+          SELECT id, username FROM " . $this->share->getTableName() . " WHERE time > DATE_SUB(now(), INTERVAL 10 MINUTE) AND our_result = 'Y'
+          UNION
+          SELECT id, username FROM " . $this->share->getArchiveTableName() ." WHERE time > DATE_SUB(now(), INTERVAL 10 MINUTE) AND our_result = 'Y'
+        ) AS t1
         GROUP BY account
         ORDER BY hashrate DESC LIMIT ?");
       if ($this->checkStmt($stmt) && $stmt->bind_param("i", $limit) && $stmt->execute() && $result = $stmt->get_result())
@@ -347,15 +372,14 @@ class Statistics {
     if ($data = $this->memcache->get(__FUNCTION__ . $account_id)) return $data;
     $stmt = $this->mysqli->prepare("
       SELECT
-      	ROUND(COUNT(s.id) * POW(2, " . $this->config['difficulty'] . ") / 3600 / 1000) AS hashrate,
+        ROUND(COUNT(s.id) * POW(2, " . $this->config['difficulty'] . ") / 3600 / 1000) AS hashrate,
         HOUR(s.time) AS hour
       FROM " . $this->share->getTableName() . " AS s, accounts AS a
       WHERE time < NOW() - INTERVAL 1 HOUR
         AND time > NOW() - INTERVAL 25 HOUR
         AND a.username = SUBSTRING_INDEX( s.username, '.', 1 )
         AND a.id = ?
-      GROUP BY HOUR(time)
-    ");
+      GROUP BY HOUR(time)");
     if ($this->checkStmt($stmt) && $stmt->bind_param("i", $account_id) && $stmt->execute() && $result = $stmt->get_result()) {
       $aData = array();
       while ($row = $result->fetch_assoc()) {
@@ -367,7 +391,7 @@ class Statistics {
     $this->debug->append("Failed to fetch hourly hashrate: " . $this->mysqli->error);
     return false;
   }
-  
+
   /**
    * get Hourly hashrate for the pool 
    * @param none
@@ -378,13 +402,13 @@ class Statistics {
     if ($this->getGetCache() && $data = $this->memcache->get(__FUNCTION__)) return $data;
     $stmt = $this->mysqli->prepare("
       SELECT
-      	ROUND(COUNT(s.id) * POW(2, " . $this->config['difficulty'] . ") / 3600 / 1000) AS hashrate,
+      ROUND(COUNT(s.id) * POW(2, " . $this->config['difficulty'] . ") / 3600 / 1000) AS hashrate,
         HOUR(s.time) AS hour
-      FROM " . $this->share->getTableName() . " AS s
-      WHERE time < NOW() - INTERVAL 1 HOUR
+        FROM " . $this->share->getTableName() . " AS s
+        WHERE time < NOW() - INTERVAL 1 HOUR
         AND time > NOW() - INTERVAL 25 HOUR
-      GROUP BY HOUR(time)
-    ");
+        GROUP BY HOUR(time)
+        ");
     if ($this->checkStmt($stmt) && $stmt->execute() && $result = $stmt->get_result()) {
       while ($row = $result->fetch_assoc()) {
         $aData[$row['hour']] = $row['hashrate'];


### PR DESCRIPTION
If the shares archive table is used via config option, those shares are
included when calculating the users hashrate. This will help on very
short rounds where each round end deletes all shares and users will not
be able to track their hashrates. They will be very jumpy and change to
0 all the time.

Still missing this implementation for the hourly hashrate function to
ensure the graphs are always kept up-to-date.

Partially fixes #332 , missing hourly hashrate stats.
