### PR TITLE
Properly allow '0' as a workername or password

### DIFF
--- a/public/include/classes/worker.class.php
+++ b/public/include/classes/worker.class.php
@@ -49,11 +49,15 @@ class Worker {
     $username = $this->user->getUserName($account_id);
     $iFailed = 0;
     foreach ($data as $key => $value) {
-      // Prefix the WebUser to Worker name
-      $value['username'] = "$username." . $value['username'];
-      $stmt = $this->mysqli->prepare("UPDATE $this->table SET password = ?, username = ?, monitor = ? WHERE account_id = ? AND id = ?");
-      if ( ! ( $this->checkStmt($stmt) && $stmt->bind_param('ssiii', $value['password'], $value['username'], $value['monitor'], $account_id, $key) && $stmt->execute()) )
+      if ('' === $value['username'] || '' === $value['password']) {
         $iFailed++;
+      } else {
+        // Prefix the WebUser to Worker name
+        $value['username'] = "$username." . $value['username'];
+        $stmt = $this->mysqli->prepare("UPDATE $this->table SET password = ?, username = ?, monitor = ? WHERE account_id = ? AND id = ?");
+        if ( ! ( $this->checkStmt($stmt) && $stmt->bind_param('ssiii', $value['password'], $value['username'], $value['monitor'], $account_id, $key) && $stmt->execute()) )
+          $iFailed++;
+      }
     }
     if ($iFailed == 0)
       return true;
@@ -154,8 +158,8 @@ class Worker {
    **/
   public function addWorker($account_id, $workerName, $workerPassword) {
     $this->debug->append("STA " . __METHOD__, 4);
-    if (empty($workerName) || empty($workerPassword)) {
-      $this->setErrorMessage('Worker and password may not be empty');
+    if ('' === $workerName || '' === $workerPassword) {
+      $this->setErrorMessage('Worker name and/or password may not be empty');
       return false;
     }
     $username = $this->user->getUserName($account_id);


### PR DESCRIPTION
This fixes #347 as recommended at

http://de3.php.net/manual/en/function.empty.php

We allow anything else than an empty string.
