### PR TITLE
Use poolhash rate if nethash is smaller

### DIFF
--- a/public/include/smarty_globals.inc.php
+++ b/public/include/smarty_globals.inc.php
@@ -28,6 +28,9 @@ $iCurrentActiveWorkers = $worker->getCountAllActiveWorkers();
 $iCurrentPoolHashrate =  $statistics->getCurrentHashrate();
 $iCurrentPoolShareRate = $statistics->getCurrentShareRate();
 
+// Avoid confusion, ensure our nethash isn't higher than poolhash
+if ($iCurrentPoolHashrate > $dNetworkHashrate) $dNetworkHashrate = $iCurrentPoolHashrate;
+
 // Global data for Smarty
 $aGlobal = array(
   'slogan' => $config['website']['slogan'],


### PR DESCRIPTION
This should avoid some confusion for coins where the network hashrate
drops under the pool hashrate due to slow block finding rates.

Fixes #378
