### PR TITLE
Hard coded block limit for pool statistics

### DIFF
--- a/public/include/pages/statistics/blocks.inc.php
+++ b/public/include/pages/statistics/blocks.inc.php
@@ -5,7 +5,7 @@ if (!defined('SECURITY')) die('Hacking attempt');
 if (!$user->isAuthenticated()) header("Location: index.php?page=home");
 
 // Grab the last blocks found
-empty($_REQUEST['limit']) ? $iLimit = 20 : $iLimit = $_REQUEST['limit'];
+$iLimit = 20;
 $aBlocksFoundData = $statistics->getBlocksFound($iLimit);
 
 // Propagate content our template


### PR DESCRIPTION
This should fix a potential DoS like attack when fetching a random
amount of blocks continously.

Fixes #387
