### PR TITLE
Fixing issue with delayed inserts for shares

### DIFF
--- a/cronjobs/findblock.php
+++ b/cronjobs/findblock.php
@@ -77,7 +77,7 @@ if (empty($aAllBlocks)) {
   foreach ($aAllBlocks as $iIndex => $aBlock) {
     if (empty($aBlock['share_id'])) {
       // Fetch this blocks upstream ID
-      if ($share->setUpstream($block->getLastUpstreamId(), $aBlock['time'])) {
+      if ($share->setUpstream($block->getLastUpstreamId())) {
         $iCurrentUpstreamId = $share->getUpstreamId();
         $iAccountId = $user->getUserId($share->getUpstreamFinder());
       } else {

--- a/public/include/classes/share.class.php
+++ b/public/include/classes/share.class.php
@@ -177,16 +177,15 @@ class Share {
    * @param last int Skips all shares up to last to find new share
    * @return bool
    **/
-  public function setUpstream($last=0, $time=0) {
+  public function setUpstream($last=0) {
     $stmt = $this->mysqli->prepare("
       SELECT
       SUBSTRING_INDEX( `username` , '.', 1 ) AS account, id
       FROM $this->table
       WHERE upstream_result = 'Y'
       AND id > ?
-      AND UNIX_TIMESTAMP(time) >= ?
       ORDER BY id ASC LIMIT 1");
-    if ($this->checkStmt($stmt) && $stmt->bind_param('ii', $last, $time) && $stmt->execute() && $result = $stmt->get_result()) {
+    if ($this->checkStmt($stmt) && $stmt->bind_param('i', $last) && $stmt->execute() && $result = $stmt->get_result()) {
       $this->oUpstream = $result->fetch_object();
       if (!empty($this->oUpstream->account) && is_int($this->oUpstream->id))
         return true;


### PR DESCRIPTION
When shares are inserted with a delay for performance optimizations,
this will cause block timestamps to be completely off with share
timestamps. Hence the timestamp limited search is now removed, it would
cause too many issues for Stratum users/pools.

Addresses #392
