### PR TITLE
Abort payout process if `share_id` is missing

### DIFF
--- a/cronjobs/pps_payout.php
+++ b/cronjobs/pps_payout.php
@@ -113,6 +113,7 @@ if (empty($aAllBlocks)) {
 foreach ($aAllBlocks as $iIndex => $aBlock) {
   // If we are running through more than one block, check for previous share ID
   $iLastBlockShare = @$aAllBlocks[$iIndex - 1]['share_id'] ? @$aAllBlocks[$iIndex - 1]['share_id'] : 0;
+  if (!is_numeric($aBlock['share_id'])) die("Block " . $aBlock['height'] . " has no share_id associated with it, not going to continue\n");
   // Per account statistics
   $aAccountShares = $share->getSharesForAccounts(@$iLastBlockShare, $aBlock['share_id']);
   foreach ($aAccountShares as $key => $aData) {

--- a/cronjobs/proportional_payout.php
+++ b/cronjobs/proportional_payout.php
@@ -40,12 +40,13 @@ foreach ($aAllBlocks as $iIndex => $aBlock) {
   if (!$aBlock['accounted']) {
     $iPreviousShareId = @$aAllBlocks[$iIndex - 1]['share_id'] ? $aAllBlocks[$iIndex - 1]['share_id'] : 0;
     $iCurrentUpstreamId = $aBlock['share_id'];
+    if (!is_numeric($iCurrentUpstreamId)) die("Block " . $aBlock['height'] . " has no share_id associated with it, not going to continue\n");
     $aAccountShares = $share->getSharesForAccounts($iPreviousShareId, $aBlock['share_id']);
     $iRoundShares = $share->getRoundShares($iPreviousShareId, $aBlock['share_id']);
     $config['reward_type'] == 'block' ? $dReward = $aBlock['amount'] : $dReward = $config['reward'];
 
     if (empty($aAccountShares)) {
-      verbose("\nNo shares found for this block\n\n");
+      verbose("\nNo shares found for this block: " . $aBlock['height'] . " \n\n");
       sleep(2);
       continue;
     }


### PR DESCRIPTION
If we have a block with NO `share_id` we abort the entire process. Less
of an issue with proportional since PPS is still being paid out, but a
block round will never actually end.

This will allow for manual intervention by the user. Otherwise blocks
found after the one having issues might trigger the payout process and
pay out shares of the old block in a more recently found one.

Please use #392 for further help on this, I have yet to replicate the
unknown block finder issue with the proper amount of upstream shares.
