### PR TITLE
Adding statistics cron to monitoring

### DIFF
--- a/cronjobs/statistics.php
+++ b/cronjobs/statistics.php
@@ -55,4 +55,6 @@ $log->logInfo("getAllUserShares " . number_format(microtime(true) - $start, 2) .
 foreach ($aUserShares as $aShares) {
   $memcache->setCache('getUserShares'. $aShares['id'], $aShares);
 }
+
+require_once('cron_end.inc.php');
 ?>

--- a/public/include/pages/admin/monitoring.inc.php
+++ b/public/include/pages/admin/monitoring.inc.php
@@ -11,6 +11,12 @@ if (!$user->isAuthenticated() || !$user->isAdmin($_SESSION['USERDATA']['id'])) {
 
 // Fetch settings to propagate to template
 $aCronStatus = array(
+  'statistics' => array (
+    array( 'NAME' => 'Exit Code', 'STATUS' => $monitoring->getStatus('statistics_status') ),
+    array( 'NAME' => 'Last Message', 'STATUS' => $monitoring->getStatus('statistics_message') ),
+    array( 'NAME' => 'Active', 'STATUS' => $monitoring->getStatus('statistics_active') ),
+    array( 'NAME' => 'Runtime', 'STATUS' => $monitoring->getStatus('statistics_runtime') )
+  ),
   'auto_payout' => array (
     array( 'NAME' => 'Exit Code', 'STATUS' => $monitoring->getStatus('auto_payout_status') ),
     array( 'NAME' => 'Last Message', 'STATUS' => $monitoring->getStatus('auto_payout_message') ),


### PR DESCRIPTION
Useful to trace cron runtimes in order to adjust caching times for long
rounds.

Addresses #145 and adds a new cron to monitoring page
