### PR TITLE
Fix CRONHOME detection if a symlink is used

### DIFF
--- a/cronjobs/run-crons.sh
+++ b/cronjobs/run-crons.sh
@@ -28,7 +28,11 @@ VERBOSE="0"
 ################################################################
 
 # Find scripts path
-CRONHOME=$( dirname $0 )
+if [[ -L $0 ]]; then
+  CRONHOME=$( dirname $( readlink $0 ) )
+else 
+  CRONHOME=$( dirname $0 )
+fi
 
 # Change working director to CRONHOME
 if ! cd $CRONHOME 2>/dev/null; then


### PR DESCRIPTION
This will fix CRONHOME detection if `run-rcrons.sh` is a symlink in `/etc/cron.minutely`.
Before symlinks would not return the proper path.
