### PR TITLE
Get rid of Orphan transaction types

### DIFF
--- a/cronjobs/blockupdate.php
+++ b/cronjobs/blockupdate.php
@@ -41,7 +41,7 @@ foreach ($aAllBlocks as $iIndex => $aBlock) {
   $log->logInfo($aBlock['id'] . "\t" . $aBlock['height'] .  "\t" . $aBlock['blockhash'] . "\t" . $aBlock['confirmations'] . " -> " . $aBlockInfo['confirmations']);
   if ($aTxDetails['details'][0]['category'] == 'orphan') {
     // We have an orphaned block, we need to invalidate all transactions for this one
-    if ($transaction->setOrphan($aBlock['id']) && $block->setConfirmations($aBlock['id'], -1)) {
+    if ($block->setConfirmations($aBlock['id'], -1)) {
       $log->logInfo("    Block marked as orphan");
     } else {
       $log->logError("    Block became orphaned but unable to update database entries");

--- a/public/templates/mmcFE/account/transactions/default.tpl
+++ b/public/templates/mmcFE/account/transactions/default.tpl
@@ -17,15 +17,9 @@
 {assign var=has_confirmed value=false}
 {section transaction $TRANSACTIONS}
         {if (
-          (($TRANSACTIONS[transaction].type == 'Credit' or $TRANSACTIONS[transaction].type == 'Bonus')and $TRANSACTIONS[transaction].confirmations >= $GLOBAL.confirmations)
-          or ($TRANSACTIONS[transaction].type == 'Donation' and $TRANSACTIONS[transaction].confirmations >= $GLOBAL.confirmations)
-          or ($TRANSACTIONS[transaction].type == 'Fee' and $TRANSACTIONS[transaction].confirmations >= $GLOBAL.confirmations)
-          or $TRANSACTIONS[transaction].type == 'Credit_PPS'
-          or $TRANSACTIONS[transaction].type == 'Fee_PPS'
-          or $TRANSACTIONS[transaction].type == 'Donation_PPS'
-          or $TRANSACTIONS[transaction].type == 'Debit_AP'
-          or $TRANSACTIONS[transaction].type == 'Debit_MP'
-          or $TRANSACTIONS[transaction].type == 'TXFee'
+          ( ( $TRANSACTIONS[transaction].type == 'Credit' or $TRANSACTIONS[transaction].type == 'Bonus' or $TRANSACTIONS[transaction].type == 'Donation' or $TRANSACTIONS[transaction].type == 'Fee' ) and $TRANSACTIONS[transaction].confirmations >= $GLOBAL.confirmations )
+          or $TRANSACTIONS[transaction].type == 'Credit_PPS' or $TRANSACTIONS[transaction].type == 'Fee_PPS' or $TRANSACTIONS[transaction].type == 'Donation_PPS'
+          or $TRANSACTIONS[transaction].type == 'Debit_AP' or $TRANSACTIONS[transaction].type == 'Debit_MP' or $TRANSACTIONS[transaction].type == 'TXFee'
         )}
         {assign var=has_credits value=true}
         <tr class="{cycle values="odd,even"}">
@@ -67,11 +61,9 @@
       <tbody style="font-size:12px;">
 {assign var=has_unconfirmed value=false}
 {section transaction $TRANSACTIONS}
-        {if (
-          ($TRANSACTIONS[transaction].type == 'Credit' or $TRANSACTIONS[transaction].type == 'Bonus') and $TRANSACTIONS[transaction].confirmations < $GLOBAL.confirmations
-          or ($TRANSACTIONS[transaction].type == 'Donation' and $TRANSACTIONS[transaction].confirmations < $GLOBAL.confirmations)
-          or ($TRANSACTIONS[transaction].type == 'Fee' and $TRANSACTIONS[transaction].confirmations < $GLOBAL.confirmations)
-        )}
+        {if
+          (($TRANSACTIONS[transaction].type == 'Credit' or $TRANSACTIONS[transaction].type == 'Bonus' or $TRANSACTIONS[transaction].type == 'Donation' or $TRANSACTIONS[transaction].type == 'Fee') and $TRANSACTIONS[transaction].confirmations < $GLOBAL.confirmations)
+        }
         {assign var=has_unconfirmed value=true}
         <tr class="{cycle values="odd,even"}">
           <td>{$TRANSACTIONS[transaction].id}</td>
@@ -117,12 +109,7 @@
       <tbody style="font-size:12px;">
 {assign var=has_orphaned value=false}
 {section transaction $TRANSACTIONS}
-        {if (
-          $TRANSACTIONS[transaction].type == 'Orphan_Credit'
-          or $TRANSACTIONS[transaction].type == 'Orphan_Donation'
-          or $TRANSACTIONS[transaction].type == 'Orphan_Fee'
-          or $TRANSACTIONS[transaction].type == 'Orphan_Bonus'
-        )}
+        {if ($TRANSACTIONS[transaction].type == 'Credit' or $TRANSACTIONS[transaction].type == 'Fee' or $TRANSACTIONS[transaction].type == 'Donation' or $TRANSACTIONS[transaction].type == 'Bonus') and $TRANSACTIONS[transaction].confirmations == -1}
         <tr class="{cycle values="odd,even"}">
           <td>{$TRANSACTIONS[transaction].id}</td>
           <td>{$TRANSACTIONS[transaction].timestamp}</td>
@@ -131,7 +118,7 @@
           <td>{if $TRANSACTIONS[transaction].height == 0}n/a{else}{$TRANSACTIONS[transaction].height}{/if}</td>
           <td><font color="{if $TRANSACTIONS[transaction].type == 'Orphan_Credit' or $TRANSACTIONS[transaction].type == 'Orphan_Bonus'}green{else}red{/if}">{$TRANSACTIONS[transaction].amount|number_format:"8"}</td>
         </tr>
-          {if $TRANSACTIONS[transaction].type == 'Orphan_Credit' or $TRANSACTIONS[transaction].type == 'Orphan_Bonus'}
+          {if $TRANSACTIONS[transaction].type == 'Credit' or $TRANSACTIONS[transaction].type == 'Bonus'}
             {assign var="orphan_credits" value="`$orphan_credits|default:"0"+$TRANSACTIONS[transaction].amount`"}
           {else}
             {assign var="orphan_debits" value="`$orphan_debits|default:"0"+$TRANSACTIONS[transaction].amount`"}

--- a/public/templates/mmcFE/admin/transactions/default.tpl
+++ b/public/templates/mmcFE/admin/transactions/default.tpl
@@ -21,15 +21,9 @@
       {assign var=confirmed value=0}
 {section transaction $TRANSACTIONS}
         {if (
-          (($TRANSACTIONS[transaction].type == 'Credit' or $TRANSACTIONS[transaction].type == 'Bonus')and $TRANSACTIONS[transaction].confirmations >= $GLOBAL.confirmations)
-          or ($TRANSACTIONS[transaction].type == 'Donation' and $TRANSACTIONS[transaction].confirmations >= $GLOBAL.confirmations)
-          or ($TRANSACTIONS[transaction].type == 'Fee' and $TRANSACTIONS[transaction].confirmations >= $GLOBAL.confirmations)
-          or $TRANSACTIONS[transaction].type == 'Credit_PPS'
-          or $TRANSACTIONS[transaction].type == 'Fee_PPS'
-          or $TRANSACTIONS[transaction].type == 'Donation_PPS'
-          or $TRANSACTIONS[transaction].type == 'Debit_AP'
-          or $TRANSACTIONS[transaction].type == 'Debit_MP'
-          or $TRANSACTIONS[transaction].type == 'TXFee'
+          ( ( $TRANSACTIONS[transaction].type == 'Credit' or $TRANSACTIONS[transaction].type == 'Bonus' or $TRANSACTIONS[transaction].type == 'Donation' or $TRANSACTIONS[transaction].type == 'Fee' ) and $TRANSACTIONS[transaction].confirmations >= $GLOBAL.confirmations )
+          or $TRANSACTIONS[transaction].type == 'Credit_PPS' or $TRANSACTIONS[transaction].type == 'Fee_PPS' or $TRANSACTIONS[transaction].type == 'Donation_PPS'
+          or $TRANSACTIONS[transaction].type == 'Debit_AP' or $TRANSACTIONS[transaction].type == 'Debit_MP' or $TRANSACTIONS[transaction].type == 'TXFee'
         )}
         {assign var=confirmed value=1}
         <tr class="{cycle values="odd,even"}">
@@ -74,11 +68,7 @@
       <tbody style="font-size:12px;">
       {assign var=unconfirmed value=0}
 {section transaction $TRANSACTIONS}
-        {if (
-          ($TRANSACTIONS[transaction].type == 'Credit' or $TRANSACTIONS[transaction].type == 'Bonus') and $TRANSACTIONS[transaction].confirmations < $GLOBAL.confirmations
-          or ($TRANSACTIONS[transaction].type == 'Donation' and $TRANSACTIONS[transaction].confirmations < $GLOBAL.confirmations)
-          or ($TRANSACTIONS[transaction].type == 'Fee' and $TRANSACTIONS[transaction].confirmations < $GLOBAL.confirmations)
-        )}
+        {if ($TRANSACTIONS[transaction].type == 'Credit' or $TRANSACTIONS[transaction].type == 'Bonus' or $TRANSACTIONS[transaction].type == 'Donation' or $TRANSACTIONS[transaction].type == 'Fee') and $TRANSACTIONS[transaction].confirmations < $GLOBAL.confirmations}
         {assign var=unconfirmed value=1}
         <tr class="{cycle values="odd,even"}">
           <td>{$TRANSACTIONS[transaction].id}</td>
@@ -118,12 +108,7 @@
       <tbody style="font-size:12px;">
       {assign var=orphaned value=0}
 {section transaction $TRANSACTIONS}
-        {if (
-          $TRANSACTIONS[transaction].type == 'Orphan_Credit'
-          or $TRANSACTIONS[transaction].type == 'Orphan_Donation'
-          or $TRANSACTIONS[transaction].type == 'Orphan_Fee'
-          or $TRANSACTIONS[transaction].type == 'Orphan_Bonus'
-        )}
+        {if ($TRANSACTIONS[transaction].type == 'Credit' or $TRANSACTIONS[transaction].type == 'Fee' or $TRANSACTIONS[transaction].type == 'Donation' or $TRANSACTIONS[transaction].type == 'Bonus') and $TRANSACTIONS[transaction].confirmations == -1}
         {assign var=orphaned value=1}
         <tr class="{cycle values="odd,even"}">
           <td>{$TRANSACTIONS[transaction].id}</td>

--- a/public/templates/mmcFE/global/sidebar_pplns.tpl
+++ b/public/templates/mmcFE/global/sidebar_pplns.tpl
@@ -67,6 +67,7 @@
                     <tr><td colspan="2"><b><u>{$GLOBAL.config.currency} Account Balance</u></b></td></tr>
                     <tr><td>Confirmed</td><td class="right"><b>{$GLOBAL.userdata.balance.confirmed|default:"0"}</td></tr>
                     <tr><td>Unconfirmed</td><td class="right"><b>{$GLOBAL.userdata.balance.unconfirmed|default:"0"}</td></tr>
+                    <tr><td>Orphaned</td><td class="right"><b>{$GLOBAL.userdata.balance.orphaned|default:"0"}</td></tr>
                   </table>
                 </div>
               <div class="bendl"></div>

--- a/public/templates/mmcFE/global/sidebar_prop.tpl
+++ b/public/templates/mmcFE/global/sidebar_prop.tpl
@@ -62,6 +62,7 @@
                     <tr><td colspan="2"><b><u>{$GLOBAL.config.currency} Account Balance</u></b></td></tr>
                     <tr><td>Confirmed</td><td class="right"><b>{$GLOBAL.userdata.balance.confirmed|default:"0"}</td></tr>
                     <tr><td>Unconfirmed</td><td class="right"><b>{$GLOBAL.userdata.balance.unconfirmed|default:"0"}</td></tr>
+                    <tr><td>Orphaned</td><td class="right"><b>{$GLOBAL.userdata.balance.orphaned|default:"0"}</td></tr>
                   </table>
                 </div>
               <div class="bendl"></div>


### PR DESCRIPTION
This fixes #432 and puts orphans on the same system as unconfirmed
transactions.
