### PR TITLE
Catch errors on missing templates

### DIFF
--- a/public/templates/mmcFE/master.tpl
+++ b/public/templates/mmcFE/master.tpl
@@ -59,7 +59,7 @@
               <div class="message {$smarty.session.POPUP[popup].TYPE|default:"success"}"><p>{$smarty.session.POPUP[popup].CONTENT}</p></div>
             {/section}
           {/if}
-          {include file="$PAGE/$ACTION/$CONTENT"}
+          {if file_exists($smarty.current_dir|cat:"/$PAGE/$ACTION/$CONTENT")}{include file="$PAGE/$ACTION/$CONTENT"}{else}Missing template for this page{/if}
         </div>
         <div class"clear"></div>
         <div id="footer" style="font-size: 10px;">

--- a/public/templates/mobile/master.tpl
+++ b/public/templates/mobile/master.tpl
@@ -47,7 +47,7 @@
       </div>
       {/if}
       <div data-role="content">
-{include file="$PAGE/$ACTION/$CONTENT"}
+{if file_exists($smarty.current_dir|cat:"/$PAGE/$ACTION/$CONTENT")}{include file="$PAGE/$ACTION/$CONTENT"}{else}Missing template for this page{/if}
       </div><!-- /content -->
       <div data-role="footer" data-position="fixed">
 {include file="global/footer.tpl"}


### PR DESCRIPTION
Pages that are missing a template will cause a error 500. We now catch
this and display a default string.

Fixes #513
