### PR TITLE
Fixing notifications for findblocks cron

### DIFF
--- a/cronjobs/findblock.php
+++ b/cronjobs/findblock.php
@@ -115,7 +115,7 @@ if (empty($aAllBlocks)) {
         . $share->share_type
       );
 
-      if ($setting->getValue('disable_notification') != 1) {
+      if ($setting->getValue('disable_notifications') != 1) {
         // Notify users
         $aAccounts = $notification->getNotificationAccountIdByType('new_block');
         if (is_array($aAccounts)) {


### PR DESCRIPTION
If disabled, findblocks would still send out notifications.

Thanks @feeleep75 for the heads up.

Fixes #522
