### PR TITLE
Fixing round estimates on public stats page

### DIFF
--- a/public/include/smarty_globals.inc.php
+++ b/public/include/smarty_globals.inc.php
@@ -12,14 +12,13 @@ $dDifficulty = 1;
 $aRoundShares = 1;
 
 // Only run these if the user is logged in
-if (@$_SESSION['AUTHENTICATED']) {
-  $aRoundShares = $statistics->getRoundShares();
-  if ($bitcoin->can_connect() === true) {
-    $dDifficulty = $bitcoin->query('getdifficulty');
-    if (is_array($dDifficulty) && array_key_exists('proof-of-work', $dDifficulty))
-      $dDifficulty = $dDifficulty['proof-of-work'];
-  }
+$aRoundShares = $statistics->getRoundShares();
+if ($bitcoin->can_connect() === true) {
+  $dDifficulty = $bitcoin->query('getdifficulty');
+  if (is_array($dDifficulty) && array_key_exists('proof-of-work', $dDifficulty))
+    $dDifficulty = $dDifficulty['proof-of-work'];
 }
+
 // Always fetch this since we need for ministats header
 $bitcoin->can_connect() === true ? $dNetworkHashrate = $bitcoin->query('getnetworkhashps') : $dNetworkHashrate = 0;
 


### PR DESCRIPTION
- Fix: Display round restimates when making pool stats public via ACL
- Fix: Display proper pool efficiency when pool stats are public

Fixes #585
