### PR TITLE
[FIX] Incorrectly reported Unconfirmed coins in wallet for alt coin amounts

### DIFF
--- a/cronjobs/blockupdate.php
+++ b/cronjobs/blockupdate.php
@@ -34,7 +34,7 @@ if ( $bitcoin->can_connect() !== true ) {
 }
 
 // Fetch all unconfirmed blocks
-$aAllBlocks = $block->getAllUnconfirmed($config['confirmations']);
+$aAllBlocks = $block->getAllUnconfirmed($config['network_confirmations']);
 
 $log->logInfo("ID\tHeight\tBlockhash\tConfirmations");
 foreach ($aAllBlocks as $iIndex => $aBlock) {

--- a/public/include/classes/block.class.php
+++ b/public/include/classes/block.class.php
@@ -133,7 +133,7 @@ class Block {
    * @param confirmations int Required confirmations to consider block confirmed
    * @return data array Array with database fields as keys
    **/
-  public function getAllUnconfirmed($confirmations=120) {
+  public function getAllUnconfirmed($confirmations) {
     $stmt = $this->mysqli->prepare("SELECT * FROM $this->table WHERE confirmations < ? AND confirmations > -1");
     if ($this->checkStmt($stmt) && $stmt->bind_param("i", $confirmations) && $stmt->execute() && $result = $stmt->get_result())
       return $result->fetch_all(MYSQLI_ASSOC);


### PR DESCRIPTION
On coins with a number other than 120 as the required amount of network confirmations, sometime the wallets incorrectly report the number of unconfirmed coins due to blockupdate only updating a blocks confirmation based on the config entry of ['confirmations']. I think it should continue to update the number of confirmations based on ['network_confirmations']. This way, when classes/block.class.php searched for unconfirmed blocks, it will find all blocks with less than ['network_confirmations'] blocks. Assuming the config file is correct, this should give the correct amount of Unconfirmed currency in your wallet. This is my first code commit, so I apologize if I have done this incorrectly.
