### PR TITLE
[FIX] Incorrectly reporting # of unconfirmed coins

### DIFF
--- a/cronjobs/blockupdate.php
+++ b/cronjobs/blockupdate.php
@@ -34,7 +34,7 @@ if ( $bitcoin->can_connect() !== true ) {
 }
 
 // Fetch all unconfirmed blocks
-$aAllBlocks = $block->getAllUnconfirmed($config['confirmations']);
+$aAllBlocks = $block->getAllUnconfirmed($config['network_confirmations']);
 
 $log->logInfo("ID\tHeight\tBlockhash\tConfirmations");
 foreach ($aAllBlocks as $iIndex => $aBlock) {


### PR DESCRIPTION
This should cause blockupdate.php to continue incrementing confirmations in the database until confirmations=network_confirmations. This will allow block.classes.php to correctly count the # of coins unconfirmed where confirmations < network_confirmations.
