### PR TITLE
Added space after Pool Title on MPOS Theme

### DIFF
--- a/public/site_assets/mpos/css/layout.css
+++ b/public/site_assets/mpos/css/layout.css
@@ -42,6 +42,7 @@ background: #222222 url(../images/header_bg.png) repeat-x;
 header#header h1.site_title, header#header h2.section_title {
 float: left;
 margin: 0;
+padding-right: 1.8%;
 font-size: 22px;
 display: inline-block;
 height: 55px;


### PR DESCRIPTION
Should at least address #722 for Chrome and IE...
