### PR TITLE
[FIX] Incorrectly reporting # of unconfirmed coins

### DIFF
--- a/cronjobs/blockupdate.php
+++ b/cronjobs/blockupdate.php
@@ -34,7 +34,7 @@ if ( $bitcoin->can_connect() !== true ) {
 }
 
 // Fetch all unconfirmed blocks
-$aAllBlocks = $block->getAllUnconfirmed($config['network_confirmations']);
+$aAllBlocks = $block->getAllUnconfirmed(max($config['network_confirmations'],$config['confirmations']));
 
 $log->logInfo("ID\tHeight\tBlockhash\tConfirmations");
 foreach ($aAllBlocks as $iIndex => $aBlock) {


### PR DESCRIPTION
Fixes #720 and fixes #721.
This will work in all three cases:

1) $config['confirmations'] > $config['network_confirmations'])
2) $config['confirmations'] < $config['network_confirmations'])
3) $config['confirmations'] = $config['network_confirmations'])
