### PR TITLE
[FIX] Skip uptime robot with defaults set

### DIFF
--- a/cronjobs/tickerupdate.php
+++ b/cronjobs/tickerupdate.php
@@ -28,6 +28,7 @@ require_once('shared.inc.php');
 // Include additional file not set in autoloader
 require_once(CLASS_DIR . '/tools.class.php');
 
+// Fetch latest coin price via API call
 if ($price = $tools->getPrice()) {
   $log->logDebug("Price update: found $price as price");
   if (!$setting->setValue('price', $price))
@@ -36,14 +37,15 @@ if ($price = $tools->getPrice()) {
   $log->logError("failed to fetch API data: " . $tools->getCronError());
 }
 
-if ($setting->getValue('monitoring_uptimerobot_private_key')) {
+// Update Uptime Robot status in Settings table via API call
+if ($api_keys = $setting->getValue('monitoring_uptimerobot_api_keys') && strstr($api_keys, '<API KEY>|<MONITOR ID>')) {
   $monitoring->setTools($tools);
   if (!$monitoring->storeUptimeRobotStatus()) {
     $log->logError($monitoring->getCronError());
-    $monitoring->endCronjob($cron_name, 'E0017', 1, true);
+    $monitoring->endCronjob($cron_name, 'E0017', 1, false);
   }
 } else {
-  $log->logDebug('Skipped Uptime Robot API update, missing private key');
+  $log->logDebug('Skipped Uptime Robot API update, missing api keys');
 }
 
 require_once('cron_end.inc.php');

--- a/public/include/classes/monitoring.class.php
+++ b/public/include/classes/monitoring.class.php
@@ -12,7 +12,7 @@ class Monitoring extends Base {
    * @return bool true on success, false on error
    **/
   public function storeUptimeRobotStatus() {
-    if ($api_keys = $this->setting->getValue('monitoring_uptimerobot_private_key')) {
+    if ($api_keys = $this->setting->getValue('monitoring_uptimerobot_api_keys')) {
       $aJSONData = array();
       $url = 'http://api.uptimerobot.com';
       $aMonitors = explode(',', $api_keys);

--- a/public/include/config/admin_settings.inc.php
+++ b/public/include/config/admin_settings.inc.php
@@ -280,9 +280,9 @@ $aSettings['recaptcha'][] = array(
 );
 $aSettings['monitoring'][] = array(
   'display' => 'Uptime Robot Private API Key', 'type' => 'text',
-  'size' => 25,
+  'size' => 100,
   'default' => '<API KEY>|<MONITOR ID>,<API KEY>|<MONITOR ID>, ...',
-  'name' => 'monitoring_uptimerobot_private_key', 'value' => $setting->getValue('monitoring_uptimerobot_private_key'),
+  'name' => 'monitoring_uptimerobot_api_keys', 'value' => $setting->getValue('monitoring_uptimerobot_api_keys'),
   'tooltip' => 'Create per-monitor API keys and save them here to propagate your uptime statistics.'
 );
 


### PR DESCRIPTION
This will skip any updates if we detect the default string in our
settings table. Otherwise the script will return an error and disable
itself.

Fixes #839 once merged
