### PR TITLE
[FIX] Coins without nethashrate in getmininginfo

### DIFF
--- a/public/include/classes/bitcoinwrapper.class.php
+++ b/public/include/classes/bitcoinwrapper.class.php
@@ -48,15 +48,21 @@ class BitcoinWrapper extends BitcoinClient {
     if ($data = $this->memcache->get(__FUNCTION__)) return $data;
     try {
       $dNetworkHashrate = $this->query('getmininginfo');
-      if (is_array($dNetworkHashrate) && array_key_exists('networkhashps', $dNetworkHashrate)) {
-        $dNetworkHashrate = $dNetworkHashrate['networkhashps'];
-      } else if (is_array($dNetworkHashrate) && array_key_exists('hashespersec', $dNetworkHashrate)) {
-        $dNetworkHashrate = $dNetworkHashrate['hashespersec'];
-      } else if (is_array($dNetworkHashrate) && array_key_exists('netmhashps', $dNetworkHashrate)) {
-        $dNetworkHashrate = $dNetworkHashrate['netmhashps'] * 1000 * 1000;
+      if (is_array($dNetworkHashrate)) {
+        if (array_key_exists('networkhashps', $dNetworkHashrate)) {
+          $dNetworkHashrate = $dNetworkHashrate['networkhashps'];
+        } else if (array_key_exists('hashespersec', $dNetworkHashrate)) {
+          $dNetworkHashrate = $dNetworkHashrate['hashespersec'];
+        } else if (array_key_exists('netmhashps', $dNetworkHashrate)) {
+          $dNetworkHashrate = $dNetworkHashrate['netmhashps'] * 1000 * 1000;
+        } else {
+          // Unsupported implementation
+          $dNetworkHashrate = 0;
+        }
       }
     } catch (Exception $e) {
-      return false;
+      // getmininginfo does not exist, cache for an hour
+      return $this->memcache->setCache(__FUNCTION__, 0, 3600);
     }
     return $this->memcache->setCache(__FUNCTION__, $dNetworkHashrate, 30);
   }


### PR DESCRIPTION
Fixes issues with coins that did not implement a proper array index into
their `getmininginfo` output. Currently supported keys are
- networkhashps
- hashespersec
- netmhashps

If none of there are found or `getmininginfo` fails itself, we now
default to `0` to ensure the webfrontend still works.

Fixes #847 and also fixes #834 which has not reported back the
required information.
