### PR TITLE
Changed sender email field max length

### DIFF
--- a/public/templates/mpos/contactform/default.tpl
+++ b/public/templates/mpos/contactform/default.tpl
@@ -10,7 +10,7 @@
       </fieldset>
       <fieldset>
         <label for="senderEmail">Your Email Address</label>
-        <input type="text" class="text tiny" name="senderEmail" value="{$smarty.request.senderEmail|escape|default:""}" placeholder="Please type your email" size="50"  maxlength="20" required />
+        <input type="text" class="text tiny" name="senderEmail" value="{$smarty.request.senderEmail|escape|default:""}" placeholder="Please type your email" size="50"  maxlength="50" required />
       </fieldset>
       <fieldset>
         <label for="senderEmail">Your Subject</label>


### PR DESCRIPTION
It should be 254 (http://stackoverflow.com/questions/386294/what-is-the-maximum-length-of-a-valid-email-address), but that seems improbable.. so I would go with 50 chars max, instead of 20 that cuts 4 out of 10 emails I receive.
Addresses #856 email field part...
