### PR TITLE
[IMPROVED] Use limits for DELETE statements

### DIFF
--- a/public/include/classes/share.class.php
+++ b/public/include/classes/share.class.php
@@ -172,8 +172,8 @@ class Share Extends Base {
    **/
   public function purgeArchive() {
     // Fallbacks if unset
-    if (!isset($this->config['purge']['shares'])) $this->config['purge']['shares'] = 500000;
-    if (!isset($this->config['purge']['sleep'])) $this->config['purge']['sleep'] = 5;
+    if (!isset($this->config['purge']['shares'])) $this->config['purge']['shares'] = 25000;
+    if (!isset($this->config['purge']['sleep'])) $this->config['purge']['sleep'] = 1;
 
     if ($this->config['payout_system'] == 'pplns') {
       // Fetch our last block so we can go back configured rounds
@@ -246,14 +246,15 @@ class Share Extends Base {
    **/
   public function deleteAccountedShares($current_upstream, $previous_upstream=0) {
     // Fallbacks if unset
-    if (!isset($this->config['purge']['shares'])) $this->config['purge']['shares'] = 500000;
-    if (!isset($this->config['purge']['sleep'])) $this->config['purge']['sleep'] = 5;
+    if (!isset($this->config['purge']['shares'])) $this->config['purge']['shares'] = 25000;
+    if (!isset($this->config['purge']['sleep'])) $this->config['purge']['sleep'] = 1;
 
     $affected = 1;
     while ($affected > 0) {
       // Sleep first to allow any IO to cleanup
       sleep($this->config['purge']['sleep']);
       $stmt = $this->mysqli->prepare("DELETE FROM $this->table WHERE id > ? AND id <= ? LIMIT " . $this->config['purge']['shares']);
+      $start = microtime(true);
       if ($this->checkStmt($stmt) && $stmt->bind_param('ii', $previous_upstream, $current_upstream) && $stmt->execute()) {
         $affected = $stmt->affected_rows;
       } else {

--- a/public/include/config/global.inc.dist.php
+++ b/public/include/config/global.inc.dist.php
@@ -241,8 +241,8 @@ $config['payout_system'] = 'prop';
  *   sleep   :  5 seconds
  *   shares  :  500000
  **/
-$config['purge']['sleep'] = 5;
-$config['purge']['shares'] = 500000;
+$config['purge']['sleep'] = 1;
+$config['purge']['shares'] = 25000;
 
 /**
  * Archiving configuration for debugging


### PR DESCRIPTION
This will address #886. Long rounds can cause a system to become
very unresponsive due to high SQL/IO load when doing cleanups of
shares and archived tables.
- Run DELETE from shares with LIMIT
- Run DELETE from shares_archive with LIMIT
- Configure DELETE behaviour via config file
- Only archive shares that are really required (PROP, PPS)

Should greatly improve round ends on PROP and PPS after large rounds,
also improves PPLNS though archving will still take some time unless
we limit the share amount artificially. Shares could be needed though,
so we don't.
