### PR TITLE
[SECURITY] Clear cache before sending a mail

### DIFF
--- a/public/include/classes/mail.class.php
+++ b/public/include/classes/mail.class.php
@@ -56,6 +56,9 @@ class Mail extends Base {
    *     email   : Destination address
    **/
   public function sendMail($template, $aData) {
+    // Make sure we don't load a cached filed
+    $this->smarty->clearCache(BASEPATH . 'templates/mail/' . $template  . '.tpl');
+    $this->smarty->clearCache(BASEPATH . 'templates/mail/subject.tpl');
     $this->smarty->assign('WEBSITENAME', $this->setting->getValue('website_name'));
     $this->smarty->assign('SUBJECT', $aData['subject']);
     $this->smarty->assign('DATA', $aData);


### PR DESCRIPTION
Will fix an issue with users receiving wrong mails, e.g. during password
resets ONLY IF smarty cache is enabled.

Please update ASAP if you have smarty caches enabled! This is a very big
issue. By default smarty caches are disabled and not recommended to be
used. See configuration file.

Fixes #899 once merged.
