### PR TITLE
[FIX] Disable caching for mail data

### DIFF
--- a/public/templates/mail/contactform/body.tpl
+++ b/public/templates/mail/contactform/body.tpl
@@ -1,10 +1,10 @@
 <html>
 <body>
 <p>{$WEBSITENAME} Message,</p>
-<p>{$DATA.senderName} Sent you a message</p>
-<p>Senders Email: {$DATA.senderEmail}</p>
-<p>Subject: {$DATA.senderSubject}</p>
-<p>Personal message:</p><p>{$DATA.senderMessage}</p>
+<p>{nocache}{$DATA.senderName}{/nocache} Sent you a message</p>
+<p>Senders Email: {nocache}{$DATA.senderEmail}{/nocache}</p>
+<p>Subject: {nocache}{$DATA.senderSubject}{/nocache}</p>
+<p>Personal message:</p><p>{nocache}{$DATA.senderMessage}{/nocache}</p>
 <p></p>
 </body>
 </html>

--- a/public/templates/mail/invitations/body.tpl
+++ b/public/templates/mail/invitations/body.tpl
@@ -1,9 +1,9 @@
 <html>
 <body>
 <p>Hello valued miner,</p><br />
-<p>{$DATA.username} invited you to participate on this pool:
-<p>http://{$smarty.server.SERVER_NAME}{$smarty.server.PHP_SELF}?page=register&token={$DATA.token}</p>
-{if $DATA.message}<p>Personal message:</p><p>{$DATA.message}</p>{/if}
+<p>{nocache}{$DATA.username}{/nocache} invited you to participate on this pool:
+<p>http://{$smarty.server.SERVER_NAME}{$smarty.server.PHP_SELF}?page=register&token={nocache}{$DATA.token}{/nocache}</p>
+{if $DATA.message}<p>Personal message:</p><p>{nocache}{$DATA.message}{/nocache}</p>{/if}
 <p></p>
 <p>Cheers,</p>
 <p>Website Administration</p>

--- a/public/templates/mail/notifications/auto_payout.tpl
+++ b/public/templates/mail/notifications/auto_payout.tpl
@@ -1,7 +1,7 @@
 <html>
 <body>
 <p>An automated payout completed.</p>
-<p>Amount: {$DATA.amount}</p>
+<p>Amount: {nocache}{$DATA.amount}{/nocache}</p>
 <br/>
 <br/>
 </body>

--- a/public/templates/mail/notifications/error.tpl
+++ b/public/templates/mail/notifications/error.tpl
@@ -5,6 +5,7 @@
   <tr>
     <td>
     <table cellpadding="0" cellspacing="1" border="0" align="left" width="800px">
+{nocache}
 {foreach from=$DATA key=text item=message}
   {if $text != 'email' && $text != 'subject'}
       <tr>
@@ -13,6 +14,7 @@
       </tr>
   {/if}
 {/foreach}
+{/nocache}
     </table>
     </td>
   </tr>

--- a/public/templates/mail/notifications/idle_worker.tpl
+++ b/public/templates/mail/notifications/idle_worker.tpl
@@ -1,6 +1,6 @@
 <html>
 <body>
-<p>One of your workers is currently IDLE: {$DATA.worker}</p>
+<p>One of your workers is currently IDLE: {nocache}{$DATA.worker}{/nocache}</p>
 <p>We have not received any shares for this worker in the past 10 minutes.</p>
 <p>Since monitoring is enabled for this worker, this notification was sent.</p>
 <br />

--- a/public/templates/mail/notifications/manual_payout.tpl
+++ b/public/templates/mail/notifications/manual_payout.tpl
@@ -1,7 +1,7 @@
 <html>
 <body>
 <p>An manual payout request completed.</p>
-<p>Amount: {$DATA.amount}</p>
+<p>Amount: {nocache}{$DATA.amount}{/nocache}</p>
 <br/>
 <br/>
 </body>

--- a/public/templates/mail/password/reset.tpl
+++ b/public/templates/mail/password/reset.tpl
@@ -1,8 +1,8 @@
 <html>
 <body>
-<p>Hello {$DATA.username},</p><br />
+<p>Hello {nocache}{$DATA.username}{/nocache},</p><br />
 <p>You have requested a password reset through our online form. In order to complete the request please follow this link:</p>
-<p>http://{$smarty.server.SERVER_NAME}{$smarty.server.PHP_SELF}?page=password&action=change&token={$DATA.token}</p>
+<p>http://{$smarty.server.SERVER_NAME}{$smarty.server.PHP_SELF}?page=password&action=change&token={nocache}{$DATA.token}{/nocache}</p>
 <p>You will be asked to change your password. You can then use this new password to login to your account.</p>
 <p>Cheers,</p>
 <p>Website Administration</p>

--- a/public/templates/mail/register/confirm_email.tpl
+++ b/public/templates/mail/register/confirm_email.tpl
@@ -1,8 +1,8 @@
 <html>
 <body>
-<p>Hello {$DATA.username},</p><br />
+<p>Hello {nocache}{$DATA.username}{/nocache},</p><br />
 <p>You have create a new account. In order to complete the registration process please follow this link:</p>
-<p>http://{$smarty.server.SERVER_NAME}{$smarty.server.PHP_SELF}?page=account&action=confirm&token={$DATA.token}</p>
+<p>http://{$smarty.server.SERVER_NAME}{$smarty.server.PHP_SELF}?page=account&action=confirm&token={nocache}{$DATA.token}{/nocache}</p>
 <p></p>
 <p>Cheers,</p>
 <p>Website Administration</p>

--- a/public/templates/mail/subject.tpl
+++ b/public/templates/mail/subject.tpl
@@ -1,1 +1,1 @@
-[ {$WEBSITENAME} ] {$SUBJECT}
+[ {$WEBSITENAME} ] {nocache}{$SUBJECT}{/nocache}


### PR DESCRIPTION
Additional fix for #899 to make sure we don't cache any data. In case that a clearCache call fails, we simply don't cache sensitive data.
