### PR TITLE
[ADDED] getInfo output to wallet information

### DIFF
--- a/public/include/pages/admin/wallet.inc.php
+++ b/public/include/pages/admin/wallet.inc.php
@@ -13,13 +13,14 @@ if (!$smarty->isCached('master.tpl', $smarty_cache_key)) {
   $debug->append('No cached version available, fetching from backend', 3);
   if ($bitcoin->can_connect() === true){
     $dBalance = $bitcoin->query('getbalance');
-    $dGetInfo = $bitcoin->query('getinfo');
-    if (is_array($dGetInfo) && array_key_exists('newmint', $dGetInfo)) {
-      $dNewmint = $dGetInfo['newmint'];
+    $aGetInfo = $bitcoin->query('getinfo');
+    if (is_array($aGetInfo) && array_key_exists('newmint', $aGetInfo)) {
+      $dNewmint = $aGetInfo['newmint'];
     } else {
       $dNewmint = -1;
     }
   } else {
+    $aGetInfo = array('errors' => 'Unable to connect');
     $dBalance = 0;
     $dNewmint = -1;
     $_SESSION['POPUP'][] = array('CONTENT' => 'Unable to connect to wallet RPC service: ' . $bitcoin->can_connect(), 'TYPE' => 'errormsg');
@@ -45,6 +46,7 @@ $smarty->assign("BALANCE", $dBalance);
 $smarty->assign("COLDCOINS", $dColdCoins);
 $smarty->assign("LOCKED", $dLockedBalance);
 $smarty->assign("NEWMINT", $dNewmint);
+$smarty->assign("COININFO", $aGetInfo);
 
 // Tempalte specifics
 $smarty->assign("CONTENT", "default.tpl");

--- a/public/templates/mpos/admin/wallet/default.tpl
+++ b/public/templates/mpos/admin/wallet/default.tpl
@@ -1,6 +1,6 @@
 <article class="module width_quarter">
-  <header><h3>Wallet Information</h3></header>
-  <table width="25%" class="tablesorter">
+  <header><h3>Balance Summary</h3></header>
+  <table width="25%" class="tablesorter" cellspacing="0">
   <tr>
     <td align="left">Wallet Balance</td>
     <td align="left">{$BALANCE|number_format:"8"}</td>
@@ -24,4 +24,26 @@
   </tr>
 {/if}
 </table>
+</article>
+
+<article class="module width_3_quarter">
+  <header><h3>Wallet Information</h3></header>
+  <table class="tablesorter" cellspacing="0">
+    <thead>
+      <th align="center">Version</th>
+      <th align="center">Protocol Version</th>
+      <th align="center">Wallet Version</th>
+      <th align="center">Connections</th>
+      <th align="center">Errors</th>
+    </thead>
+    <tbody>
+      <tr>
+        <td align="center">{$COININFO.version|default:""}</td>
+        <td align="center">{$COININFO.protocolversion|default:""}</td>
+        <td align="center">{$COININFO.walletversion|default:""}</td>
+        <td align="center">{$COININFO.connections|default:""}</td>
+        <td align="center"><font color="{if $COININFO.errors}red{else}green{/if}">{$COININFO.errors|default:"OK"}</font></td>
+      </tr>
+    </tbody>
+  </table>
 </article>


### PR DESCRIPTION
Adds some additional wallet infos to the wallet info page in the admin
panel. Specifically the errors output might be interesting for users not
checking their RPC regularly for mandatory updates.

Fixes #912 once merged.
