### PR TITLE
[CHANGED] Do not send mail on uptime robot update

### DIFF
--- a/cronjobs/tickerupdate.php
+++ b/cronjobs/tickerupdate.php
@@ -43,7 +43,7 @@ if ($api_keys = $setting->getValue('monitoring_uptimerobot_api_keys')) {
     $monitoring->setTools($tools);
     if (!$monitoring->storeUptimeRobotStatus()) {
       $log->logError($monitoring->getCronError());
-      $monitoring->endCronjob($cron_name, 'E0017', 1, false);
+      $monitoring->endCronjob($cron_name, 'E0017', 1, false, false);
     }
   }
 } else {


### PR DESCRIPTION
Do not send a mail notification in case the uptime robot updates are
failing.

Fixes #897 once merged.
