### PR TITLE
Calling $this from static context

### DIFF
--- a/public/include/classes/bitcoin.class.php
+++ b/public/include/classes/bitcoin.class.php
@@ -211,7 +211,7 @@ class Bitcoin {
    * @access public
    */
   public static function pubKeyToAddress($pubkey) {
-    return self::hash160ToAddress($this->hash160($pubkey));
+    return self::hash160ToAddress(self::hash160($pubkey));
   }
 
   /**


### PR DESCRIPTION
Patch fixes a small but where $this is being called from a static method. The static function pubKeyToAddress() was calling $this->hash160(). Changed to self::hash160().
