### PR TITLE
Undefined property: Notification::$mail

### DIFF
--- a/public/include/classes/notification.class.php
+++ b/public/include/classes/notification.class.php
@@ -155,7 +155,7 @@ class Notification extends Mail {
       if ($stmt->close() && $this->sendMail('notifications/' . $strType, $aMailData) && $this->addNotification($account_id, $strType, $aMailData)) {
         return true;
       } else {
-        $this->setErrorMessage('SendMail call failed: ' . $this->mail->getError());
+        $this->setErrorMessage('SendMail call failed: ' . $this->getError());
         return false;
       }
     } else {


### PR DESCRIPTION
I'm not 100% sure this is a bug, but I'm getting the following error from my crons.

> PHP Notice:  Undefined property: Notification::$mail in /var/www/MPOS/public/include/classes/notification.class.php on line 158
> 
> PHP Fatal error:  Call to a member function getError() on a non-object in /var/www/MPOS/public/include/classes/notification.class.php on line 158

It appears the `Notification` class extends the `Mail` class instead of `Base`, in which case `$this->mail` does not exist.
