### PR TITLE
[FiX] Division by zero warning on $dNetworkHashrate

### DIFF
--- a/public/include/classes/statistics.class.php
+++ b/public/include/classes/statistics.class.php
@@ -812,7 +812,7 @@ class Statistics extends Base {
       $dNetworkHashrate = $this->bitcoin->getnetworkhashps();
       $dDifficulty = $this->bitcoin->getdifficulty();
     } else {
-      $dNetworkHashrate = 0;
+      $dNetworkHashrate = 1;
       $dDifficulty = 1;
     }
 


### PR DESCRIPTION
When not connected to a wallet, the value of $dnetworkHashrate is set to 0, which causes a division by zero error.
