### PR TITLE
[IMPROVED] Transaction data handling

### DIFF
--- a/public/include/classes/transaction.class.php
+++ b/public/include/classes/transaction.class.php
@@ -102,7 +102,6 @@ class Transaction extends Base {
     $this->debug->append("STA " . __METHOD__, 4);
     $sql = "
       SELECT
-        SQL_CALC_FOUND_ROWS
         t.id AS id,
         a.username as username,
         t.type AS type,
@@ -160,21 +159,13 @@ class Transaction extends Base {
         $sql .= implode(' AND ', $aFilter);
       }
     }
-    $sql .= "
-      ORDER BY id DESC
-      LIMIT ?,?
-      ";
+    $sql .= " ORDER BY id DESC LIMIT ?,?";
     // Add some other params to query
     $this->addParam('i', $start);
     $this->addParam('i', $limit);
     $stmt = $this->mysqli->prepare($sql);
-    if ($this->checkStmt($stmt) && call_user_func_array( array($stmt, 'bind_param'), $this->getParam()) && $stmt->execute() && $result = $stmt->get_result()) {
-      // Fetch matching row count
-      $num_rows = $this->mysqli->prepare("SELECT FOUND_ROWS() AS num_rows");
-      if ($num_rows->execute() && $row_count = $num_rows->get_result()->fetch_object()->num_rows)
-        $this->num_rows = $row_count;
+    if ($this->checkStmt($stmt) && call_user_func_array( array($stmt, 'bind_param'), $this->getParam()) && $stmt->execute() && $result = $stmt->get_result())
       return $result->fetch_all(MYSQLI_ASSOC);
-    }
     return $this->sqlError();
   }
 

--- a/public/include/config/admin_settings.inc.php
+++ b/public/include/config/admin_settings.inc.php
@@ -287,6 +287,13 @@ $aSettings['system'][] = array(
   'name' => 'disable_dashboard_api', 'value' => $setting->getValue('disable_dashboard_api'),
   'tooltip' => 'Disable dashboard API entirely to reduce server load.'
 );
+$aSettings['system'][] = array(
+  'display' => 'Disable TX Summaries', 'type' => 'select',
+  'options' => array( 0 => 'No', 1 => 'Yes'),
+  'default' => 0,
+  'name' => 'disable_transactionsummary', 'value' => $setting->getValue('disable_transactionsummary'),
+  'tooltip' => 'Disable transaction summaries. Helpful with large transaction tables.'
+);
 $aSettings['recaptcha'][] = array(
   'display' => 'Enable re-Captcha', 'type' => 'select',
   'options' => array( 0 => 'No', 1 => 'Yes' ),

--- a/public/include/pages/account/transactions.inc.php
+++ b/public/include/pages/account/transactions.inc.php
@@ -6,16 +6,17 @@ if ($user->isAuthenticated()) {
   $iLimit = 30;
   empty($_REQUEST['start']) ? $start = 0 : $start = $_REQUEST['start'];
   $aTransactions = $transaction->getTransactions($start, @$_REQUEST['filter'], $iLimit, $_SESSION['USERDATA']['id']);
-  $aTransactionSummary = $transaction->getTransactionSummary($_SESSION['USERDATA']['id']);
-  $iCountTransactions = $transaction->num_rows;
   $aTransactionTypes = $transaction->getTypes();
   if (!$aTransactions) $_SESSION['POPUP'][] = array('CONTENT' => 'Could not find any transaction', 'TYPE' => 'errormsg');
+  if (!$setting->getValue('disable_transactionsummary')) {
+    $aTransactionSummary = $transaction->getTransactionSummary($_SESSION['USERDATA']['id']);
+    $smarty->assign('SUMMARY', $aTransactionSummary);
+  }
   $smarty->assign('LIMIT', $iLimit);
   $smarty->assign('TRANSACTIONS', $aTransactions);
-  $smarty->assign('SUMMARY', $aTransactionSummary);
   $smarty->assign('TRANSACTIONTYPES', $aTransactionTypes);
   $smarty->assign('TXSTATUS', array('' => '', 'Confirmed' => 'Confirmed', 'Unconfirmed' => 'Unconfirmed', 'Orphan' => 'Orphan'));
-  $smarty->assign('COUNTTRANSACTIONS', $iCountTransactions);
+  $smarty->assign('DISABLE_TRANSACTIONSUMMARY', $setting->getValue('disable_transactionsummary'));
 }
 $smarty->assign('CONTENT', 'default.tpl');
 ?>

--- a/public/include/pages/admin/transactions.inc.php
+++ b/public/include/pages/admin/transactions.inc.php
@@ -14,16 +14,17 @@ if (!$smarty->isCached('master.tpl', $smarty_cache_key)) {
   $debug->append('No cached version available, fetching from backend', 3);
   empty($_REQUEST['start']) ? $start = 0 : $start = $_REQUEST['start'];
   $aTransactions = $transaction->getTransactions($start, @$_REQUEST['filter'], $iLimit);
-  $aTransactionSummary = $transaction->getTransactionSummary();
-  $iCountTransactions = $transaction->num_rows;
   $aTransactionTypes = $transaction->getTypes();
   if (!$aTransactions) $_SESSION['POPUP'][] = array('CONTENT' => 'Could not find any transaction', 'TYPE' => 'errormsg');
+  if (!$setting->getValue('disable_transactionsummary')) {
+    $aTransactionSummary = $transaction->getTransactionSummary();
+    $smarty->assign('SUMMARY', $aTransactionSummary);
+  }
   $smarty->assign('LIMIT', $iLimit);
   $smarty->assign('TRANSACTIONS', $aTransactions);
-  $smarty->assign('SUMMARY', $aTransactionSummary);
   $smarty->assign('TRANSACTIONTYPES', $aTransactionTypes);
   $smarty->assign('TXSTATUS', array('' => '', 'Confirmed' => 'Confirmed', 'Unconfirmed' => 'Unconfirmed', 'Orphan' => 'Orphan'));
-  $smarty->assign('COUNTTRANSACTIONS', $iCountTransactions);
+  $smarty->assign('DISABLE_TRANSACTIONSUMMARY', $setting->getValue('disable_transactionsummary'));
 } else {
   $debug->append('Using cached page', 3);
 }

--- a/public/templates/mpos/account/transactions/default.tpl
+++ b/public/templates/mpos/account/transactions/default.tpl
@@ -1,3 +1,4 @@
+{if $DISABLE_TRANSACTIONSUMMARY|default:"0" != 1}
 <article class="module width_full">
   <header><h3>Transaction Summary</h3></header>
   <table class="tablesorter" cellspacing="0">
@@ -17,6 +18,7 @@
     </tbody>
   </table>
 </article>
+{/if}
 
 <article class="module width_quarter">
   <header><h3>Transaction Filter</h3></header>
@@ -27,21 +29,15 @@
     <table cellspacing="0" class="tablesorter">
     <tbody>
       <tr>
-{if $COUNTTRANSACTIONS / $LIMIT > 1}
         <td align="left">
-  {if $smarty.request.start|default:"0" > 0}
+{if $smarty.request.start|default:"0" > 0}
           <a href="{$smarty.server.PHP_SELF}?page={$smarty.request.page|escape}&action={$smarty.request.action|escape}&start={$smarty.request.start|escape|default:"0" - $LIMIT}{if $FILTERS|default:""}{$FILTERS}{/if}"><i class="icon-left-open"></i></a>
-  {else}
+{else}
           <i class="icon-left-open"></i>
-  {/if}
+{/if}
         </td>
         <td align="right">
-  {if $COUNTTRANSACTIONS - $smarty.request.start|default:"0" - $LIMIT > 0}
           <a href="{$smarty.server.PHP_SELF}?page={$smarty.request.page|escape}&action={$smarty.request.action|escape}&start={$smarty.request.start|escape|default:"0" + $LIMIT}{if $FILTERS|default:""}{$FILTERS}{/if}"><i class="icon-right-open"></i></a>
-  {else}
-          <i class="icon-right-open"></i>
-  {/if}
-{/if}
         </td>
       </tr>
     </tbody>

--- a/public/templates/mpos/admin/transactions/default.tpl
+++ b/public/templates/mpos/admin/transactions/default.tpl
@@ -1,3 +1,4 @@
+{if $DISABLE_TRANSACTIONSUMMARY|default:"0" != 1}
 <article class="module width_full">
   <header><h3>Transaction Summary</h3></header>
   <table class="tablesorter" cellspacing="0">
@@ -17,6 +18,7 @@
     </tbody>
   </table>
 </article>
+{/if}
 
 <article class="module width_quarter">
   <header><h3>Transaction Filter</h3></header>
@@ -27,21 +29,15 @@
     <table cellspacing="0" class="tablesorter">
     <tbody>
       <tr>
-{if $COUNTTRANSACTIONS / $LIMIT > 1}
         <td align="left">
-  {if $smarty.request.start|default:"0" > 0}
-          <a href="{$smarty.server.PHP_SELF}?page={$smarty.request.page|escape}&action={$smarty.request.action|escape}&start={$smarty.request.start|default:"0" - $LIMIT}{if $FILTERS|default:""}{$FILTERS}{/if}"><i class="icon-left-open"></i></a>
-  {else}
+{if $smarty.request.start|default:"0" > 0}
+          <a href="{$smarty.server.PHP_SELF}?page={$smarty.request.page|escape}&action={$smarty.request.action|escape}&start={$smarty.request.start|escape|default:"0" - $LIMIT}{if $FILTERS|default:""}{$FILTERS}{/if}"><i class="icon-left-open"></i></a>
+{else}
           <i class="icon-left-open"></i>
-  {/if}
+{/if}
         </td>
         <td align="right">
-  {if $COUNTTRANSACTIONS - $smarty.request.start|default:"0" - $LIMIT > 0}
-          <a href="{$smarty.server.PHP_SELF}?page={$smarty.request.page|escape}&action={$smarty.request.action|escape}&start={$smarty.request.start|default:"0" + $LIMIT}{if $FILTERS|default:""}{$FILTERS}{/if}"><i class="icon-right-open"></i></a>
-  {else}
-          <i class="icon-right-open"></i>
-  {/if}
-{/if}
+          <a href="{$smarty.server.PHP_SELF}?page={$smarty.request.page|escape}&action={$smarty.request.action|escape}&start={$smarty.request.start|escape|default:"0" + $LIMIT}{if $FILTERS|default:""}{$FILTERS}{/if}"><i class="icon-right-open"></i></a>
         </td>
     </tbody>
   </table>


### PR DESCRIPTION
This will improve loading times on large transaction tables. Thanks
@feeleep75 for helping with this one.
- Do not use SQL_CALC_NUM_ROWS since it will do a full table scan
- Allow admins to disable account transaction summaries to speed up page
  loads on large tables
- added new admin setting under system to Disable TX Summaries

Fixes #1065 once merged
