### PR TITLE
[FIX] Wrong behavior on Edit Account with no addy

### DIFF
--- a/public/include/classes/user.class.php
+++ b/public/include/classes/user.class.php
@@ -281,20 +281,22 @@ class User extends Base {
       $this->setErrorMessage('Invalid email address');
       return false;
     }
-    if ($this->bitcoin->can_connect() === true && !empty($address)) {
-      try {
-        $aStatus = $this->bitcoin->validateaddress($address);
-        if (!$aStatus['isvalid']) {
-          $this->setErrorMessage('Invalid coin address');
+    if (!empty($address)) {
+      if ($this->bitcoin->can_connect() === true) {
+        try {
+          $aStatus = $this->bitcoin->validateaddress($address);
+          if (!$aStatus['isvalid']) {
+            $this->setErrorMessage('Invalid coin address');
+            return false;
+          }
+        } catch (BitcoinClientException $e) {
+          $this->setErrorMessage('Unable to verify coin address');
           return false;
         }
-      } catch (BitcoinClientException $e) {
-        $this->setErrorMessage('Unable to verify coin address');
+      } else {
+        $this->setErrorMessage('Unable to connect to RPC server for coin address validation');
         return false;
       }
-    } else {
-      $this->setErrorMessage('Unable to connect to RPC server for coin address validation');
-      return false;
     }
 
     // Number sanitizer, just in case we fall through above


### PR DESCRIPTION
When an account is edited and no payment address has been set, the following non-sense message appears:
Unable to connect to RPC server for coin address validation

This patch fixes the issue and allows profile to be edited with no payment address
