### PR TITLE
[IMPROVED]

### DIFF
--- a/public/include/config/admin_settings.inc.php
+++ b/public/include/config/admin_settings.inc.php
@@ -105,6 +105,13 @@ $aSettings['statistics'][] = array(
   'tooltip' => 'How often to refresh data via ajax in seconds.'
 );
 $aSettings['statistics'][] = array(
+  'display' => 'Ajax Long Refresh Interval', 'type' => 'select',
+  'options' => array('5' => '5', '10' => '10', '15' => '15', '30' => '30', '60' => '60', '600' => '600', '1800' => '1800', '3600' => '3600' ),
+  'default' => 10,
+  'name' => 'statistics_ajax_long_refresh_interval', 'value' => $setting->getValue('statistics_ajax_long_refresh_interval'),
+  'tooltip' => 'How often to refresh data via ajax in seconds. User for SQL costly queries like getBalance and getWorkers.'
+);
+$aSettings['statistics'][] = array(
   'display' => 'Ajax Data Interval', 'type' => 'select',
   'options' => array('60' => '1', '180' => '3', '300' => '5', '600' => '10'),
   'default' => 300,

--- a/public/include/pages/api/getdashboarddata.inc.php
+++ b/public/include/pages/api/getdashboarddata.inc.php
@@ -75,9 +75,6 @@ $dPersonalHashrateAdjusted = $dPersonalHashrate * $dPersonalHashrateModifier;
 $dPoolHashrateAdjusted = $dPoolHashrate * $dPoolHashrateModifier;
 $dNetworkHashrateAdjusted = $dNetworkHashrate / 1000 * $dNetworkHashrateModifier;
 
-// Worker information
-$aWorkers = $worker->getWorkers($user_id, $interval);
-
 // Coin price
 $aPrice = $setting->getValue('price');
 
@@ -99,7 +96,7 @@ $data = array(
   'personal' => array (
     'hashrate' => $dPersonalHashrateAdjusted, 'sharerate' => $dPersonalSharerate, 'sharedifficulty' => $dPersonalShareDifficulty,
     'shares' => array('valid' => $aUserRoundShares['valid'], 'invalid' => $aUserRoundShares['invalid'], 'invalid_percent' => $dUserInvalidPercent, 'unpaid' => $dUnpaidShares ),
-    'balance' => $transaction->getBalance($user_id), 'estimates' => $aEstimates, 'workers' => $aWorkers ),
+    'estimates' => $aEstimates),
   'pool' => array(
     'info' => array(
       'name' => $setting->getValue('website_name'),

--- a/public/include/smarty_globals.inc.php
+++ b/public/include/smarty_globals.inc.php
@@ -46,6 +46,7 @@ if (!$iCurrentActiveWorkers = $worker->getCountAllActiveWorkers()) $iCurrentActi
 
 // Some settings to propagate to template
 if (! $statistics_ajax_refresh_interval = $setting->getValue('statistics_ajax_refresh_interval')) $statistics_ajax_refresh_interval = 10;
+if (! $statistics_ajax_long_refresh_interval = $setting->getValue('statistics_ajax_long_refresh_interval')) $statistics_ajax_long_refresh_interval = 10;
 
 // Small helper array
 $aHashunits = array( '1' => 'KH/s', '0.001' => 'MH/s', '0.000001' => 'GH/s' );
@@ -76,6 +77,7 @@ $aGlobal = array(
     'disable_notifications' => $setting->getValue('disable_notifications'),
     'monitoring_uptimerobot_api_keys' => $setting->getValue('monitoring_uptimerobot_api_keys'),
     'statistics_ajax_refresh_interval' => $statistics_ajax_refresh_interval,
+    'statistics_ajax_long_refresh_interval' => $statistics_ajax_long_refresh_interval,
     'price' => array( 'currency' => $config['price']['currency'] ),
     'targetdiff' => $config['difficulty'],
     'currency' => $config['currency'],


### PR DESCRIPTION
Splitting dashboard calls up instead of using one single API call:
- Use getuserbalance for Balance updates
- Use getuserworkers for Worker updates

For those and potential other SQL intensive Ajax calls I have added a
long ajax refresh interval setting. It can be set via admin panel and
will change the refresh time on the JS file on the dashboard for those
two calls.

Should help a bit with high worker and transaction volume pools.

Address #1159
