### PR TITLE
Update user.class.php

### DIFF
--- a/public/include/classes/user.class.php
+++ b/public/include/classes/user.class.php
@@ -234,7 +234,7 @@ public function generatePin($userID, $current) {
     $this->debug->append("STA " . __METHOD__, 4);
     $dPercent = $this->getSingle($userID, 'donate_percent', 'id');
     if ($dPercent > 100) $dPercent = 100;
-    if ($dPercent < 0) $dPercent = 0;
+    if ($dPercent < 0.01) $dPercent = 0;
     return $dPercent;
   }
 
@@ -297,8 +297,8 @@ public function generatePin($userID, $current) {
     if (!is_numeric($donate)) {
       $this->setErrorMessage('Invalid input for donation');
       return false;
-    } else if ($donate < 0) {
-      $this->setErrorMessage('Donation below allowed 0% limit');
+    } else if ($donate < 0.01) {
+      $this->setErrorMessage('Donation below allowed 0.01% limit');
       return false;
     } else if ($donate > 100) {
       $this->setErrorMessage('Donation above allowed 100% limit');


### PR DESCRIPTION
I have noticed it is possible to put in extremely low values for the donation percent, values like:  0.000000000000001.

According to my math, even if I mined every single dogecoin, such donation would work out to:
100,000,000,000 \* 0.00000000000000001 (0.000000000000001%) = 0.000001 which is less than the current minimum transaction amount of 1.

Would it be better to make the minimum a more sane value such as the proposed 0.01%? With this value a reward of 10,000 coins would be a modest donation of 1.

I am not against using an even lower threshold, such as 0.001, but think some sort of adjustment should be in play to keep the value reasonable. 

My main concern, and I am no expert, is that allowing such extremes would place extra load on the backend?
