### PR TITLE
Updated max lenght of username field in password-reset form

### DIFF
--- a/public/templates/mpos/password/default.tpl
+++ b/public/templates/mpos/password/default.tpl
@@ -7,7 +7,7 @@
       <p>If you have an email set for your account, enter your username to get your password reset</p>
       <fieldset>
         <label>Username or E-Mail</label>
-        <input type="text" name="username" value="{$smarty.post.username|escape|default:""}" size="22" maxlength="50" required>
+        <input type="text" name="username" value="{$smarty.post.username|escape|default:""}" size="22" maxlength="100" required>
       </fieldset>
       <div class="clear"></div>
     </div>


### PR DESCRIPTION
As the password reset form can also accept emails, increased the max-length size to 50 - so that we can accept long emails too.
