### PR TITLE
[FIX] Do not show xaxis ticks

### DIFF
--- a/public/templates/mpos/dashboard/js_api.tpl
+++ b/public/templates/mpos/dashboard/js_api.tpl
@@ -51,7 +51,7 @@ $(document).ready(function(){
     axes: {
       yaxis:  { min: 0, pad: 1.25, label: 'Hashrate' , labelRenderer: $.jqplot.CanvasAxisLabelRenderer },
       y3axis: { min: 0, pad: 1.25, label: 'Sharerate', labelRenderer: $.jqplot.CanvasAxisLabelRenderer },
-      xaxis:  { tickInterval: {/literal}{$GLOBAL.config.statistics_ajax_refresh_interval}{literal}, labelRenderer: $.jqplot.CanvasAxisLabelRenderer, renderer: $.jqplot.DateAxisRenderer, angle: 30, tickOptions: { formatString: '%T' } },
+      xaxis:  { showTicks: false, tickInterval: {/literal}{$GLOBAL.config.statistics_ajax_refresh_interval}{literal}, labelRenderer: $.jqplot.CanvasAxisLabelRenderer, renderer: $.jqplot.DateAxisRenderer, angle: 30, tickOptions: { formatString: '%T' } },
     },
   };
 


### PR DESCRIPTION
Ticks take too much room and don't convey enough information. They are
now removed.

Fixes #1276 once merged.
