### PR TITLE
    [UPDATE] Allow deletion of accounts

### DIFF
--- a/cronjobs/findblock.php
+++ b/cronjobs/findblock.php
@@ -137,13 +137,13 @@ if (empty($aAllBlocks)) {
       // Store new information
       if (!$block->setShareId($aBlock['id'], $iCurrentUpstreamId))
         $log->logError('Failed to update share ID in database for block ' . $aBlock['height'] . ': ' . $block->getCronError());
-      if (!$block->setFinder($aBlock['id'], $iAccountId))
+      if (!empty($iAccountId) && !$block->setFinder($aBlock['id'], $iAccountId))
         $log->logError('Failed to update finder account ID in database for block ' . $aBlock['height'] . ': ' . $block->getCronError());
       if (!$block->setFindingWorker($aBlock['id'], $iWorker))
         $log->logError('Failed to update worker ID in database for block ' . $aBlock['height'] . ': ' . $block->getCronError());
       if (!$block->setShares($aBlock['id'], $iRoundShares))
         $log->logError('Failed to update share count in database for block ' . $aBlock['height'] . ': ' . $block->getCronError());
-      if ($config['block_bonus'] > 0 && !$transaction->addTransaction($iAccountId, $config['block_bonus'], 'Bonus', $aBlock['id'])) {
+      if ($config['block_bonus'] > 0 && !empty($iAccountId) && !$transaction->addTransaction($iAccountId, $config['block_bonus'], 'Bonus', $aBlock['id'])) {
         $log->logError('Failed to create Bonus transaction in database for user ' . $user->getUserName($iAccountId) . ' for block ' . $aBlock['height'] . ': ' . $transaction->getCronError());
       }
 

--- a/cronjobs/pplns_payout.php
+++ b/cronjobs/pplns_payout.php
@@ -158,6 +158,12 @@ foreach ($aAllBlocks as $iIndex => $aBlock) {
 
     // Loop through all accounts that have found shares for this round
     foreach ($aAccountShares as $key => $aData) {
+      // Skip entries that have no account ID, user deleted?
+      if (empty($aData['id'])) {
+        $log->logInfo('User ' . $aData['username'] . ' does not have an associated account, skipping');
+        continue;
+      }
+
       // Payout based on PPLNS target shares, proportional payout for all users
       $aData['percentage'] = round(( 100 / $iRoundShares) * $aData['valid'], 8);
       $aData['payout'] = round(( $aData['percentage'] / 100 ) * $dReward, 8);

--- a/cronjobs/pps_payout.php
+++ b/cronjobs/pps_payout.php
@@ -80,6 +80,12 @@ if (!empty($aAccountShares)) {
 }
 
 foreach ($aAccountShares as $aData) {
+  // Skip entries that have no account ID, user deleted?
+  if (empty($aData['id'])) {
+    $log->logInfo('User ' . $aData['username'] . ' does not have an associated account, skipping');
+    continue;
+  }
+
   // MPOS uses a base difficulty setting to avoid showing weightened shares
   // Since we need weightened shares here, we go back to the proper value for payouts
   $aData['payout'] = round($aData['valid'] * pow(2, ($config['difficulty'] - 16)) * $pps_value, 8);

--- a/cronjobs/proportional_payout.php
+++ b/cronjobs/proportional_payout.php
@@ -72,12 +72,17 @@ foreach ($aAllBlocks as $iIndex => $aBlock) {
 
     // Loop through all accounts that have found shares for this round
     foreach ($aAccountShares as $key => $aData) {
-      // Payout based on shares, PPS system
-      $aData['percentage'] = round(( 100 / $iRoundShares ) * $aData['valid'], 8);
-      $aData['payout'] = round(( $aData['percentage'] / 100 ) * $dReward, 8);
+      // Skip entries that have no account ID, user deleted?
+      if (empty($aData['id'])) {
+        $log->logInfo('User ' . $aData['username'] . ' does not have an associated account, skipping');
+        continue;
+      }
+
       // Defaults
       $aData['fee' ] = 0;
       $aData['donation'] = 0;
+      $aData['percentage'] = round(( 100 / $iRoundShares ) * $aData['valid'], 8);
+      $aData['payout'] = round(( $aData['percentage'] / 100 ) * $dReward, 8);
 
       if ($config['fees'] > 0 && $aData['no_fees'] == 0)
         $aData['fee'] = round($config['fees'] / 100 * $aData['payout'], 8);

--- a/public/templates/mpos/statistics/round/block_stats.tpl
+++ b/public/templates/mpos/statistics/round/block_stats.tpl
@@ -37,7 +37,7 @@
         <td>Shares</td>
         <td>{$BLOCKDETAILS.shares|number_format:"0"|default:"0"}</td>
         <td>Finder</td>
-        <td>{$BLOCKDETAILS.finder|default:"0"}</td>
+        <td>{$BLOCKDETAILS.finder|default:"unknown"}</td>
       </tr>
     </tbody>
   </table>

--- a/public/templates/mpos/statistics/round/pplns_block_stats.tpl
+++ b/public/templates/mpos/statistics/round/pplns_block_stats.tpl
@@ -76,7 +76,7 @@
       </tr>
       <tr class="even">
         <td>Finder</td>
-        <td>{$BLOCKDETAILS.finder|default:"0"}</td>
+        <td>{$BLOCKDETAILS.finder|default:"unknown"}</td>
         <td>Round Variance</td>
         <td>{if $PPLNSSHARES > 0}{math assign="percentage1" equation=(($BLOCKDETAILS.shares / $PPLNSSHARES) * 100)}{/if}<font color="{if ($percentage1 >= 100)}green{else}red{/if}">{$percentage1|number_format:"2"} %</font></td>
       </tr>

--- a/public/templates/mpos/statistics/round/pplns_block_stats_small.tpl
+++ b/public/templates/mpos/statistics/round/pplns_block_stats_small.tpl
@@ -63,7 +63,7 @@
         <td>Shares</td>
         <td>{$BLOCKDETAILS.shares|number_format:"0"|default:"0"}</td>
         <td>Finder</td>
-        <td>{$BLOCKDETAILS.finder|default:"0"}</td>
+        <td>{$BLOCKDETAILS.finder|default:"unknown"}</td>
         <td>Seconds This Round</td>
         <td>{$BLOCKDETAILS.round_time|number_format:"0"|default:"0"}</td>
         <td>Round Variance</td>

--- a/public/templates/mpos/statistics/round/pplns_round_shares.tpl
+++ b/public/templates/mpos/statistics/round/pplns_round_shares.tpl
@@ -15,7 +15,7 @@
 {section contrib $PPLNSROUNDSHARES}
       <tr{if $GLOBAL.userdata.username|default:"" == $PPLNSROUNDSHARES[contrib].username} style="background-color:#99EB99;"{else} class="{cycle values="odd,even"}"{/if}>
         <td align="center">{$rank++}</td>
-        <td>{if $PPLNSROUNDSHARES[contrib].is_anonymous|default:"0" == 1 && $GLOBAL.userdata.is_admin|default:"0" == 0}anonymous{else}{$PPLNSROUNDSHARES[contrib].username|escape}{/if}</td>
+        <td>{if $PPLNSROUNDSHARES[contrib].is_anonymous|default:"0" == 1 && $GLOBAL.userdata.is_admin|default:"0" == 0}anonymous{else}{$PPLNSROUNDSHARES[contrib].username|default:"unknown"|escape}{/if}</td>
         <td align="right">{$PPLNSROUNDSHARES[contrib].pplns_valid|number_format}</td>
         <td align="right">{$PPLNSROUNDSHARES[contrib].pplns_invalid|number_format}</td>
 	<td align="right" style="padding-right: 25px;">{if $PPLNSROUNDSHARES[contrib].pplns_invalid > 0 && $PPLNSROUNDSHARES[contrib].pplns_valid > 0}{($PPLNSROUNDSHARES[contrib].pplns_invalid / $PPLNSROUNDSHARES[contrib].pplns_valid * 100)|number_format:"2"|default:"0"}{else}0.00{/if}</td>

--- a/public/templates/mpos/statistics/round/pplns_transactions.tpl
+++ b/public/templates/mpos/statistics/round/pplns_transactions.tpl
@@ -16,7 +16,7 @@
 {assign var=percentage1 value=0}
 {section txs $ROUNDTRANSACTIONS}
       <tr{if $GLOBAL.userdata.username|default:"" == $ROUNDTRANSACTIONS[txs].username}{assign var=listed value=1} style="background-color:#99EB99;"{else} class="{cycle values="odd,even"}"{/if}>
-        <td>{if $ROUNDTRANSACTIONS[txs].is_anonymous|default:"0" == 1 && $GLOBAL.userdata.is_admin|default:"0" == 0}anonymous{else}{$ROUNDTRANSACTIONS[txs].username|escape}{/if}</td>
+        <td>{if $ROUNDTRANSACTIONS[txs].is_anonymous|default:"0" == 1 && $GLOBAL.userdata.is_admin|default:"0" == 0}anonymous{else}{$ROUNDTRANSACTIONS[txs].username|default:"unknown"|escape}{/if}</td>
         <td align="right">{$ROUNDSHARES[$ROUNDTRANSACTIONS[txs].uid].valid|number_format}</td>
         <td align="right">{if $ROUNDSHARES[$ROUNDTRANSACTIONS[txs].uid].valid > 0 }{(( 100 / $BLOCKDETAILS.shares) * $ROUNDSHARES[$ROUNDTRANSACTIONS[txs].uid].valid)|number_format:"2"}{else}0.00{/if}</td>
         <td align="right">{$PPLNSROUNDSHARES[txs].pplns_valid|number_format|default:"0"}</td>

--- a/public/templates/mpos/statistics/round/pplns_transactions_small.tpl
+++ b/public/templates/mpos/statistics/round/pplns_transactions_small.tpl
@@ -19,7 +19,7 @@
     <tbody>
 {section txs $ROUNDTRANSACTIONS}
       <tr{if $GLOBAL.userdata.username|default:"" == $ROUNDTRANSACTIONS[txs].username}{assign var=listed value=1} style="background-color:#99EB99;"{else} class="{cycle values="odd,even"}"{/if}>
-        <td>{if $ROUNDTRANSACTIONS[txs].is_anonymous|default:"0" == 1 && $GLOBAL.userdata.is_admin|default:"0" == 0}anonymous{else}{$ROUNDTRANSACTIONS[txs].username|escape}{/if}</td>
+        <td>{if $ROUNDTRANSACTIONS[txs].is_anonymous|default:"0" == 1 && $GLOBAL.userdata.is_admin|default:"0" == 0}anonymous{else}{$ROUNDTRANSACTIONS[txs].username|default:"unknown"|escape}{/if}</td>
         <td align="right">{$SHARESDATA[$ROUNDTRANSACTIONS[txs].username].valid|number_format}</td>
         <td align="right">{$SHARESDATA[$ROUNDTRANSACTIONS[txs].username].invalid|number_format}</td>
       	<td align="right">{if $SHARESDATA[$ROUNDTRANSACTIONS[txs].username].invalid > 0 }{($SHARESDATA[$ROUNDTRANSACTIONS[txs].username].invalid / $SHARESDATA[$ROUNDTRANSACTIONS[txs].username].valid * 100)|number_format:"2"|default:"0"}{else}0.00{/if}</td>

--- a/public/templates/mpos/statistics/round/round_shares.tpl
+++ b/public/templates/mpos/statistics/round/round_shares.tpl
@@ -16,7 +16,7 @@
 {foreach key=id item=data from=$ROUNDSHARES}
       <tr{if $GLOBAL.userdata.username|default:"" == $data.username}{assign var=listed value=1} style="background-color:#99EB99;"{else} class="{cycle values="odd,even"}"{/if}>
         <td align="center">{$rank++}</td>
-        <td>{if $data.is_anonymous|default:"0" == 1 && $GLOBAL.userdata.is_admin|default:"0" == 0}anonymous{else}{$data.username|escape}{/if}</td>
+        <td>{if $data.is_anonymous|default:"0" == 1 && $GLOBAL.userdata.is_admin|default:"0" == 0}anonymous{else}{$data.username|default:"unknown"|escape}{/if}</td>
         <td align="right">{$data.valid|number_format}</td>
         <td align="right">{$data.invalid|number_format}</td>
       	<td align="right" style="padding-right: 25px;">{if $data.invalid > 0 }{($data.invalid / $data.valid * 100)|number_format:"2"|default:"0"}{else}0.00{/if}</td>

--- a/public/templates/mpos/statistics/round/round_transactions.tpl
+++ b/public/templates/mpos/statistics/round/round_transactions.tpl
@@ -13,7 +13,7 @@
     <tbody>
 {section txs $ROUNDTRANSACTIONS}
       <tr{if $GLOBAL.userdata.username|default:"" == $ROUNDTRANSACTIONS[txs].username} style="background-color:#99EB99;"{else} class="{cycle values="odd,even"}"{/if}>
-        <td>{if $ROUNDTRANSACTIONS[txs].is_anonymous|default:"0" == 1 && $GLOBAL.userdata.is_admin|default:"0" == 0}anonymous{else}{$ROUNDTRANSACTIONS[txs].username|escape}{/if}</td>
+        <td>{if $ROUNDTRANSACTIONS[txs].is_anonymous|default:"0" == 1 && $GLOBAL.userdata.is_admin|default:"0" == 0}anonymous{else}{$ROUNDTRANSACTIONS[txs].username|default:"unknown"|escape}{/if}</td>
         <td align="center">{$ROUNDTRANSACTIONS[txs].type|default:""}</td>
         <td align="right">{$ROUNDSHARES[$ROUNDTRANSACTIONS[txs].uid].valid|number_format}</td>
         <td align="right">{(( 100 / $BLOCKDETAILS.shares) * $ROUNDSHARES[$ROUNDTRANSACTIONS[txs].uid].valid)|default:"0"|number_format:"2"}</td>


### PR DESCRIPTION
```
Updated backend and theme to be able to deal with deleted accounts

* Backends will skip any users that have no account_id associated with
  their shares
* Updated round stats theme to show users as unknown if none can be found

This will not fully address the issue of account deletion but at least
wont break the system anymore.
```
