### PR TITLE
Fix occasional error: unable to unserialize data

### DIFF
--- a/public/include/classes/statscache.class.php
+++ b/public/include/classes/statscache.class.php
@@ -41,7 +41,8 @@ class StatsCache {
     if (empty($expiration))
       $expiration = $this->config['memcache']['expiration'] + rand( -$this->config['memcache']['splay'], $this->config['memcache']['splay']);
     $this->debug->append("Storing " . $this->getRound() . '_' . $this->config['memcache']['keyprefix'] . "$key with expiration $expiration", 3);
-    return $this->cache->set($this->getRound() . '_' . $this->config['memcache']['keyprefix'] . $key, $value, $expiration);
+    $compress = is_bool($value) || is_int($value) || is_float($value) ? false : MEMCACHE_COMPRESSED;
+    return $this->cache->set($this->getRound() . '_' . $this->config['memcache']['keyprefix'] . $key, $value, $compress, $expiration);
   }
 
   /**


### PR DESCRIPTION
Fix Memcache occasional error "unable to unserialize data" that occurs when running cronjobs.

In PHP documentation, the 3 parameter for set is a flag and the 4th parameter is the expiration.
http://www.php.net/manual/en/memcache.set.php

Making this update seems to eliminate the "...unable to unserialize data..." error.  Not sure why that solves it, but it did for me.
