### PR TITLE
Pid file fix proposal for multi-pool setups

### DIFF
--- a/cronjobs/pid/README.md
+++ b/cronjobs/pid/README.md
@@ -1,0 +1,1 @@
+Place-holder for pid files. You pid's will be saved here.

--- a/cronjobs/run-crons.sh
+++ b/cronjobs/run-crons.sh
@@ -16,7 +16,7 @@ CRONS="liquid_payout.php findblock.php proportional_payout.php pplns_payout.php 
 VERBOSE="0"
 
 # Base path for PIDFILE, (full path).
-BASEPATH="/tmp"
+BASEPATH="./pid"
 
 # Subfolder for PIDFILE, so it's path will be unique in a multipool server.
 # Path relative to BASEPATH.

--- a/cronjobs/run-maintenance.sh
+++ b/cronjobs/run-maintenance.sh
@@ -16,7 +16,7 @@ CRONS="tickerupdate.php notifications.php token_cleanup.php archive_cleanup.php"
 VERBOSE="0"
 
 # Base path for PIDFILE, (full path).
-BASEPATH="/tmp"
+BASEPATH="./pid"
 
 # Subfolder for PIDFILE, so it's path will be unique in a multipool server.
 # Path relative to BASEPATH.

--- a/cronjobs/run-payout.sh
+++ b/cronjobs/run-payout.sh
@@ -16,7 +16,7 @@ CRONS="liquid_payout.php findblock.php proportional_payout.php pplns_payout.php 
 VERBOSE="0"
 
 # Base path for PIDFILE, (full path).
-BASEPATH="/tmp"
+BASEPATH="./pid"
 
 # Subfolder for PIDFILE, so it's path will be unique in a multipool server.
 # Path relative to BASEPATH.

--- a/cronjobs/run-statistics.sh
+++ b/cronjobs/run-statistics.sh
@@ -16,7 +16,7 @@ CRONS="statistics.php"
 VERBOSE="0"
 
 # Base path for PIDFILE, (full path).
-BASEPATH="/tmp"
+BASEPATH="./pid"
 
 # Subfolder for PIDFILE, so it's path will be unique in a multipool server.
 # Path relative to BASEPATH.


### PR DESCRIPTION
Although there exists subfolder support for multi-pool setups, this will not work out of box.

```
# Subfolder for PIDFILE, so it's path will be unique in a multipool server.
# Path relative to BASEPATH.
# Eg. SUBFOLDER="LTC"
SUBFOLDER=""
```

The problem is that for each merge, operator has to reset the subfolder value back..

Basically let's say operator runs 3 diff. coin pools;

```
/a
/b
/c
```

So he decides to get latest changes from php-mpos; then he has to issue the following commands;

```
cd /a
git pull
```

Git will warn about modified /a/cronjobs/run-*.sh files (as he already set SUBFOLDER value to get multi-pools working together)

At this point he needs to checkout head versions from repository where the downloaded one will just have  SUBFOLDER=""

```
git checkout /a/cronjobs/run-crons.sh
git checkout /a/cronjobs/run-maintenance.sh
git checkout /a/cronjobs/run-payout.sh
git checkout /a/cronjobs/run-statistics.sh
```

He can now get the latest changes merged;

```
git pull
```

Now he has to edit the 4 run-*.sh files and set the SUBFOLDER value correctly again.

```
pico /a/cronjobs/run-maintenance.sh
pico /a/cronjobs/run-payout.sh
pico /a/cronjobs/run-statistics.sh
```

So now he has to do the same stuff for /b and /c pools to. If has even more pools, he has to repeat more.

So I've a proposal that works out-of-the box;
- Instead of storing the cron pid files in /tmp and require operators to set a SUBFOLDER value each time, let's keep the pid's in /cronjobs/pid/ folder so each php-mpos instance can just store it's own pid's in his own space. 
- No need to checkout, merge, re-edit everytime.

Note: I didn't checked if the source changes for cron scripts are working but I guess this should just work;

```
BASEPATH="./pid"
```
