### PR TITLE
Update run-payout.sh

### DIFF
--- a/cronjobs/run-payout.sh
+++ b/cronjobs/run-payout.sh
@@ -10,7 +10,7 @@
 PHP_BIN=$( which php )
 
 # List of cruns to execute
-CRONS="liquid_payout.php findblock.php proportional_payout.php pplns_payout.php pps_payout.php blockupdate.php payouts.php"
+CRONS="findblock.php proportional_payout.php pplns_payout.php pps_payout.php blockupdate.php payouts.php liquid_payout.php"
 
 # Output additional runtime information
 VERBOSE="0"


### PR DESCRIPTION
Liquid payout was being processed before block(s) found/payout causing liquid balances to go in to the minus as the liquid payout job would see funds in wallet that were unassigned.

This change moves the liquid_payout.php cron as the last step to be performed.
