### PR TITLE
[FIX] Bail payouts on failed sendtoaddress calls

### DIFF
--- a/cronjobs/payouts.php
+++ b/cronjobs/payouts.php
@@ -68,8 +68,8 @@ if ($setting->getValue('disable_manual_payouts') != 1) {
         try {
           $txid = $bitcoin->sendtoaddress($aData['coin_address'], $dBalance - $config['txfee_manual']);
         } catch (Exception $e) {
-          $log->logError('Failed to send requested balance to coin address, please check payout process. Does the wallet cover the amount? Error:' . $e->getMessage());
-          continue;
+          $log->logFatal('Failed sending coins to user, aborting due to a coind exception in RPC call. Please check your RPC transactions.');
+          $monitoring->endCronjob($cron_name, 'E0078', 1, true);
         }
 
         if ($transaction->addTransaction($aData['account_id'], $dBalance - $config['txfee_manual'], 'Debit_MP', NULL, $aData['coin_address'], $txid) && $transaction->addTransaction($aData['account_id'], $config['txfee_manual'], 'TXFee', NULL, $aData['coin_address'])) {
@@ -132,8 +132,8 @@ if ($setting->getValue('disable_auto_payouts') != 1) {
         try {
           $txid = $bitcoin->sendtoaddress($aUserData['coin_address'], $dBalance - $config['txfee_auto']);
         } catch (Exception $e) {
-          $log->logError('Failed to send requested balance to coin address, please check payout process. Does the wallet cover the amount?');
-          continue;
+          $log->logFatal('Failed sending coins to user, aborting due to a coind exception in RPC call. Please check your RPC transactions.');
+          $monitoring->endCronjob($cron_name, 'E0078', 1, true);
         }
 
         // Create transaction record

--- a/public/include/config/error_codes.inc.php
+++ b/public/include/config/error_codes.inc.php
@@ -75,4 +75,5 @@ $aErrorCodes['E0074'] = 'Failed deleting expired tokens';
 $aErrorCodes['E0075'] = 'Upgrade required';
 $aErrorCodes['E0076'] = 'No coins in wallet available';
 $aErrorCodes['E0077'] = 'RPC method or connection failed';
+$aErrorCodes['E0078'] = 'RPC method did not return 200 OK';
 ?>


### PR DESCRIPTION
- [WORKAROUND] Helps for coins that run a bad RPC implementation
- Addresses #1406 and wil at least stop double payouts
