### PR TITLE
[FIX] checking payout address

### DIFF
--- a/cronjobs/payouts.php
+++ b/cronjobs/payouts.php
@@ -117,20 +117,20 @@ if ($setting->getValue('disable_auto_payouts') != 1) {
       $log->logInfo("\tUserID\tUsername\tBalance\tThreshold\tAddress");
       foreach ($users as $aUserData) {
         $dBalance = $aUserData['confirmed'];
-        $log->logInfo("\t" . $aUserData['id'] . "\t" . $aUserData['username'] . "\t" . $dBalance . "\t" . $aUserData['ap_threshold'] . "\t\t" . $aUserData['coin_address']);
-        // Only run if balance meets threshold and can pay the potential transaction fee
-        if ($dBalance > $aUserData['ap_threshold'] && $dBalance > $config['txfee_auto']) {
-          // Validate address against RPC
-          try {
+        // Validate address against RPC
+        try {
           $aStatus = $bitcoin->validateaddress($aUserData['coin_address']);
           if (!$aStatus['isvalid']) {
             $log->logError('Failed to verify this users coin address, skipping payout');
             continue;
-            }
-          } catch (Exception $e) {
-            $log->logError('Failed to verify this users coin address, skipping payout');
-            continue;
           }
+        } catch (Exception $e) {
+          $log->logError('Failed to verify this users coin address, skipping payout');
+          continue;
+        }
+        $log->logInfo("\t" . $aUserData['id'] . "\t" . $aUserData['username'] . "\t" . $dBalance . "\t" . $aUserData['ap_threshold'] . "\t\t" . $aUserData['coin_address']);
+        // Only run if balance meets threshold and can pay the potential transaction fee
+        if ($dBalance > $aUserData['ap_threshold'] && $dBalance > $config['txfee_auto']) {
           // Send balance, fees are reduced later by RPC Server
           try {
             $txid = $bitcoin->sendtoaddress($aUserData['coin_address'], $dBalance - $config['txfee_auto']);


### PR DESCRIPTION
- checking payout address before running payouts
- fixed wrong variable used in error logging

maybe i'm wrong, but killing the complete payout process if only one user hasn't set a valid address isn't the right solution.

but that's only my opinion :)
