### PR TITLE
(#1717) Added BitcoinWrapper::validateaddress() function

### DIFF
--- a/public/include/classes/bitcoinwrapper.class.php
+++ b/public/include/classes/bitcoinwrapper.class.php
@@ -45,6 +45,11 @@ class BitcoinWrapper extends BitcoinClient {
       $data = $data['proof-of-work'];
     return $this->memcache->setCache(__FUNCTION__, $data, 30);
   }
+  public function validateaddress($addr) {
+    $this->oDebug->append("STA " . __METHOD__, 4);
+    if ($data = $this->memcache->get(__FUNCTION__)) return $data;
+    return $this->memcache->setCache(__FUNCTION__, $addr, 30);
+  }
   public function getestimatedtime($iCurrentPoolHashrate) {
     $this->oDebug->append("STA " . __METHOD__, 4);
     if ($iCurrentPoolHashrate == 0) return 0;


### PR DESCRIPTION
Without this patch, the call to $bitcoin->validateaddress() in public/include/admin_checks.php always fails, causing the admin to be informed that their 'cold wallet address is SET and INVLAID'. This happens as long as a cold wallet address is defined, regardless of if the address is valid or not.

The problem can be traced back to public/include/classes/bitcoin.class.php where we define the BitcoinClient::validateaddress() function. This function simply returns true or false depending on the result of a call to parent::validateaddress($coin_address). In BitcoinClient's case, parent is always itcoinWrapper. However, we have never defined BitcoinWrapper::validateaddress().

To resolve this, I simply defined the BitcoinWrapper::validateaddress() function.
