### PR TITLE
Rewrite rule for non-WWW to WWW

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,3 +1,6 @@
+RewriteEngine on
+RewriteCond %{HTTP_HOST} !^www.*$ [NC]
+RewriteRule ^/.+www\/(.*)$ http://www.%{HTTP_HOST}/$1 [R=301,L]
 ErrorDocument 404 /public/index.php?page=error&action=404
 RedirectMatch 404 /logs(/|$)
 Options -Indexes


### PR DESCRIPTION
From an SEO perspective, http://site.com and http://www.site.com are separate sites.

This pull adds a rewrite rule to Apache to resolve this with a 301 redirect.
CGMINER follows this redirect so mining is unaffected.
