### PR TITLE
[FIX] Wallet Balance

### DIFF
--- a/public/include/classes/bitcoinwrapper.class.php
+++ b/public/include/classes/bitcoinwrapper.class.php
@@ -40,7 +40,7 @@ class BitcoinWrapper extends BitcoinClient {
   public function getrealbalance() {
     $this->oDebug->append("STA " . __METHOD__, 4);
     $aAccounts = parent::listaccounts();
-    $dBalance = parent::getbalance();
+    $dBalance = parent::getbalance('');
     // Account checks
     if (count($aAccounts) == 1) {
       // We only have a single account so getbalance will be fine


### PR DESCRIPTION
Fix for negative Wallet Balance, because getbalance '' returns the Wallet Balance including unconfirmed Funds. For now we are using only getbalance, which returns the Wallet Balance without unconfirmed funds and we calculate a wrong value with substracting the unconfirmed Funds from Wallet Balance.
