### PR TITLE
[UPDATE] simple robots.txt

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,5 @@
+User-agent: *
+Disallow: /templates/
+Disallow: /include/
+Disallow: /site_assets/
+Disallow: /*?page=


### PR DESCRIPTION
checked google for site indexing, there are many links indexing the blocks page and others that i don't like. makes no sense to add those sites to search engine index so i'd like to disallow them with a simple robots.txt.

```
Disallow: /*?page=
```

would only let search spiders indexing the main page, no pages with dynamic content and dynamic urls called with ?page=
