### PR TITLE
[FIX] Workaround for missing confirmations

### DIFF
--- a/cronjobs/blockupdate.php
+++ b/cronjobs/blockupdate.php
@@ -54,10 +54,18 @@ foreach ($aAllBlocks as $iIndex => $aBlock) {
     $log->logInfo(sprintf($strLogMask, $aBlock['id'], $aBlock['height'], $aBlock['blockhash'], $aBlock['confirmations'], $aBlockInfo['confirmations'], $status));
     continue;
   }
-  if ($aBlock['confirmations'] == $aBlockInfo['confirmations']) {
+  if (isset($aBlockInfo['confirmations'])) {
+    $iRPCConfirmations = $aBlockInfo['confirmations'];
+  } else if (isset($aTxDetails['confirmations'])) {
+    $iRPCConfirmations = $aTxDetails['confirmations'];
+  } else {
+    $log->logFatal('    RPC does not return any usable block confirmation information');
+    $monitoring->endCronjob($cron_name, 'E0082', 1, true);
+  }
+  if ($iRPCConfirmations == $aBlock['confirmations']) {
     continue;
   } else {
-    if (!$block->setConfirmations($aBlock['id'], $aBlockInfo['confirmations'])) {
+    if (!$block->setConfirmations($aBlock['id'], $iRPCConfirmations)) {
       $log->logError('    Failed to update block confirmations: ' . $block->getCronMessage());
       $status = 'ERROR';
     } else {
@@ -67,7 +75,7 @@ foreach ($aAllBlocks as $iIndex => $aBlock) {
       $log->logInfo(sprintf($strLogMask, 'ID', 'Height', 'Blockhash', 'Old', 'New', 'Status'));
       $header = true;
     }
-    $log->logInfo(sprintf($strLogMask, $aBlock['id'], $aBlock['height'], $aBlock['blockhash'], $aBlock['confirmations'], $aBlockInfo['confirmations'], $status));
+    $log->logInfo(sprintf($strLogMask, $aBlock['id'], $aBlock['height'], $aBlock['blockhash'], $aBlock['confirmations'], $iRPCConfirmations, $status));
   }
 }
 

--- a/public/include/config/error_codes.inc.php
+++ b/public/include/config/error_codes.inc.php
@@ -77,4 +77,5 @@ $aErrorCodes['E0078'] = 'RPC method did not return 200 OK';
 $aErrorCodes['E0079'] = 'Wallet does not cover payouts total amount';
 $aErrorCodes['E0080'] = 'No new unaccounted shares since last run';
 $aErrorCodes['E0081'] = 'Failed to insert new block into database';
+$aErrorCodes['E0082'] = 'Block does not supply any usable confirmation information';
 ?>


### PR DESCRIPTION
This will fix issues with those coins that don't track confirmations for
blocks inside the getblock RPC call. It will try to fallback to the
transactions confirmations and insert those instead.

Fixes #1823 as mentioned by @ice00 - Thanks for that!
