### PR TITLE
[SQL] Updated blocks table share_id to bigint

### DIFF
--- a/public/include/version.inc.php
+++ b/public/include/version.inc.php
@@ -2,7 +2,7 @@
 $defflip = (!cfip()) ? exit(header('HTTP/1.1 401 Unauthorized')) : 1;
 
 define('MPOS_VERSION', '0.0.4');
-define('DB_VERSION', '0.0.6');
+define('DB_VERSION', '0.0.7');
 define('CONFIG_VERSION', '0.0.7');
 
 // Fetch installed database version

--- a/sql/000_base_structure.sql
+++ b/sql/000_base_structure.sql
@@ -46,7 +46,7 @@ CREATE TABLE IF NOT EXISTS `blocks` (
   `account_id` int(255) unsigned DEFAULT NULL,
   `worker_name` varchar(50) DEFAULT 'unknown',
   `shares` int(255) unsigned DEFAULT NULL,
-  `share_id` int(255) DEFAULT NULL,
+  `share_id` bigint(30) DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `height` (`height`,`blockhash`),
   KEY `time` (`time`)
@@ -133,7 +133,7 @@ CREATE TABLE IF NOT EXISTS `settings` (
   UNIQUE KEY `setting` (`name`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
-INSERT INTO `settings` (`name`, `value`) VALUES ('DB_VERSION', '0.0.6');
+INSERT INTO `settings` (`name`, `value`) VALUES ('DB_VERSION', '0.0.7');
 
 CREATE TABLE IF NOT EXISTS `shares` (
   `id` bigint(30) NOT NULL AUTO_INCREMENT,

--- a/sql/017_blocks_update.sql
+++ b/sql/017_blocks_update.sql
@@ -1,0 +1,2 @@
+ALTER TABLE  `blocks` CHANGE  `share_id`  `share_id` BIGINT( 30 ) NULL DEFAULT NULL ;
+INSERT INTO `settings` (`name`, `value`) VALUES ('DB_VERSION', '0.0.7') ON DUPLICATE KEY UPDATE `value` = '0.0.7';


### PR DESCRIPTION
Will avoid issues with BIGINT from shares table getting too big for the
INT on the blocks share_id column.

Thanks IRC@webxassDE for the heads up!
