### PR TITLE
[ADDED] Settings Runtime Cache

### DIFF
--- a/public/include/classes/setting.class.php
+++ b/public/include/classes/setting.class.php
@@ -3,6 +3,21 @@ $defflip = (!cfip()) ? exit(header('HTTP/1.1 401 Unauthorized')) : 1;
 
 class Setting extends Base {
   protected $table = 'settings';
+  private $cache = array();
+
+  /**
+   * Fetch all values available and cache them in this class
+   * That way we don't fetch them from DB for each call
+   */
+  public function createCache() {
+    if ($aSettings = $this->getAllAssoc()) {
+      foreach ($aSettings as $key => $aData) {
+        $this->cache[$aData['name']] = $aData['value'];
+      }
+      return true;
+    }
+    return false;
+  }
 
   /**
    * Fetch a value from our table
@@ -10,6 +25,8 @@ class Setting extends Base {
    * @return value string Value
    **/
   public function getValue($name, $default="") {
+    // Try our class cache first
+    if (isset($this->cache[$name])) return $this->cache[$name];
     $stmt = $this->mysqli->prepare("SELECT value FROM $this->table WHERE name = ? LIMIT 1");
     if ($this->checkStmt($stmt) && $stmt->bind_param('s', $name) && $stmt->execute() && $result = $stmt->get_result()) {
       if ($result->num_rows > 0) {
@@ -30,6 +47,8 @@ class Setting extends Base {
    * @return bool
    **/
   public function setValue($name, $value) {
+    // Update local cache too
+    $this->cache[$name] = $value;
     $stmt = $this->mysqli->prepare("
       INSERT INTO $this->table (name, value)
       VALUES (?, ?)
@@ -44,3 +63,5 @@ $setting = new Setting($debug, $mysqli);
 $setting->setDebug($debug);
 $setting->setMysql($mysqli);
 $setting->setErrorCodes($aErrorCodes);
+// Fill our class cache with data so we don't have to run SQL queries all the time
+$setting->createCache();


### PR DESCRIPTION
Added a class-local cache to reduce the amount of SQL queries to fetch our websites settings:
- Create a local class cache with all settings available
- Try to fetch from cache if available
- Fallback to SQL if no cache is available

Caches are created during class creation in `setting.class.php`. Should reduce the SQL overhead a fair bit.
