### PR TITLE
[ADDED] Calc Coin PPS Value Method

### DIFF
--- a/cronjobs/pps_payout.php
+++ b/cronjobs/pps_payout.php
@@ -63,7 +63,7 @@ if ($config['pps']['reward']['type'] == 'blockavg' && $block->getBlockCount() > 
 }
 
 // Per-share value to be paid out to users
-$pps_value = round($pps_reward / (pow(2, $coin->getTargetBits()) * $dDifficulty), 12);
+$pps_value = round($coin->calcPPSValue($pps_reward, $dDifficulty), 12);
 
 // Find our last share accounted and last inserted share for PPS calculations
 if (!$iPreviousShareId = $setting->getValue('pps_last_share_id')) {

--- a/public/include/classes/coins/coin_base.class.php
+++ b/public/include/classes/coins/coin_base.class.php
@@ -20,6 +20,14 @@ class CoinBase extends Base {
   }
 
   /**
+   * Calculate the PPS value for this coin
+   * WARNING: Get this wrong and you will over- or underpay your miners!
+   **/
+  public function calcPPSValue($pps_reward, $dDifficulty) {
+    return ($pps_reward / (pow(2, $this->target_bits) * $dDifficulty));
+  }
+
+  /**
    * Calculate our hashrate based on shares inserted to DB
    * We use diff1 share values, not a baseline one
    **/

--- a/public/include/classes/statistics.class.php
+++ b/public/include/classes/statistics.class.php
@@ -892,7 +892,7 @@ class Statistics extends Base {
         $pps_reward = $this->config['pps']['reward']['default'];
       }
     }
-    return round($pps_reward / (pow(2, $this->coin->getTargetBits()) * $dDifficulty), 12);
+    return round($this->coin->calcPPSValue($pps_reward, $dDifficulty), 12);
   }
 
   /**


### PR DESCRIPTION
Adds a calcPPSValue method into the coin class. It's dangerous if you don't know what you are doing though, so it's only guaranteed to work for scrypt and sha256d for those who want to run PPS.
