### PR TITLE
Fix bug in admin dashboard

### DIFF
--- a/public/include/pages/admin/wallet.inc.php
+++ b/public/include/pages/admin/wallet.inc.php
@@ -18,7 +18,7 @@ if (!$smarty->isCached('master.tpl', $smarty_cache_key)) {
     $dAccountAddresses = array();
     foreach($dWalletAccounts as $key => $value)
     {
-      $dAccountAddresses[$key] = $bitcoin->getaddressesbyaccount($key);
+      $dAccountAddresses[$key] = $bitcoin->getaddressesbyaccount((string)$key);
     }
 
     $aGetInfo = $bitcoin->getinfo();


### PR DESCRIPTION
Fixes a bug causing the admin dashboard to throw an error, when the wallet has an account name which is an integer (e.g. "1").

This is caused by json_decode decoding the account name as an integer, rather than a string, which is passed to getaddressesbyaccount. This causes the page to throw an error, as the daemon only accepts string values for account names.
