### PR TITLE
Hashing improvements

### DIFF
--- a/public/include/classes/user.class.php
+++ b/public/include/classes/user.class.php
@@ -311,7 +311,7 @@ class User extends Base {
     $aData['username'] = $username;
     $aData['email'] = $email;
     $aData['pin'] = $newpin;
-    $newpin = $this->getHash($newpin, 1, bin2hex(openssl_random_pseudo_bytes(32)));
+    $newpin = $this->getHash($newpin, HASH_VERSION, bin2hex(openssl_random_pseudo_bytes(32)));
     $aData['subject'] = 'PIN Reset Request';
     $stmt = $this->mysqli->prepare("UPDATE $this->table SET pin = ? WHERE ( id = ? AND pass = ? )");
     if ($this->checkStmt($stmt) && $stmt->bind_param('sis', $newpin, $userID, $password_hash) && $stmt->execute()) {
@@ -447,7 +447,7 @@ class User extends Base {
     $strPasswordHash = $this->getUserPasswordHashById($userID);
     $aPassword = explode('$', $strPasswordHash);
     count($aPassword) == 1 ? $password_hash = $this->getHash($current, 0) : $password_hash = $this->getHash($current, $aPassword[1], $aPassword[2]);
-    $new = $this->getHash($new1, 1, bin2hex(openssl_random_pseudo_bytes(32)));
+    $new = $this->getHash($new1, HASH_VERSION, bin2hex(openssl_random_pseudo_bytes(32)));
     if ($this->config['twofactor']['enabled'] && $this->config['twofactor']['options']['changepw']) {
       $tValid = $this->token->isTokenValid($userID, $strToken, 6);
       if ($tValid) {
@@ -808,8 +808,8 @@ class User extends Base {
     }
 
     // Create hashed strings using original string and salt
-    $password_hash = $this->getHash($password1, 1, bin2hex(openssl_random_pseudo_bytes(32)));
-    $pin_hash = $this->getHash($pin, 1, bin2hex(openssl_random_pseudo_bytes(32)));
+    $password_hash = $this->getHash($password1, HASH_VERSION, bin2hex(openssl_random_pseudo_bytes(32)));
+    $pin_hash = $this->getHash($pin, HASH_VERSION, bin2hex(openssl_random_pseudo_bytes(32)));
     $apikey_hash = $this->getHash($username, 0);
     $username_clean = strip_tags($username);
     $signup_time = time();

--- a/public/include/version.inc.php
+++ b/public/include/version.inc.php
@@ -4,6 +4,7 @@ $defflip = (!cfip()) ? exit(header('HTTP/1.1 401 Unauthorized')) : 1;
 define('MPOS_VERSION', '0.0.4');
 define('DB_VERSION', '0.0.8');
 define('CONFIG_VERSION', '0.0.8');
+define('HASH_VERSION', 1);
 
 // Fetch installed database version
 $db_version = $setting->getValue('DB_VERSION');


### PR DESCRIPTION
- Added HASH_VERSION to interchange hashing systems for pins/passwords
- Added pepper as a salt hash into the final hashed string in the password/pin coloum

This will make adjusting the hashing systems at least feasible for new accounts and those that changed their password and/or PIN to the new system. A simple password change or PIN reset will do the trick.
