### PR TITLE
added scrypt-n coin-algo class for sake of completeness

### DIFF
--- a/public/include/classes/coins/coin_scryptn.class.php
+++ b/public/include/classes/coins/coin_scryptn.class.php
@@ -5,6 +5,9 @@ $defflip = (!cfip()) ? exit(header('HTTP/1.1 401 Unauthorized')) : 1;
  * We extend our CoinBase class
  * No need to change anything, base class supports
  * scrypt and sha256d
+ * 
+ * Note: This is exactly the same as Scrypt, but it's 
+ * here to let MPOS api report the correct coin algorithm.
  **/
 class Coin extends CoinBase {
   protected $target_bits = 16;


### PR DESCRIPTION
Exactly the same as coin_scrypt.class.php but now the mpos api can now correctly report the algo used by the coin - for the sake of completeness.
