### PR TITLE
[UPDATE] Hide e-mail address on account screen

### DIFF
--- a/include/classes/user.class.php
+++ b/include/classes/user.class.php
@@ -496,7 +496,7 @@ class User extends Base {
       $this->setErrorMessage('Donation above allowed 100% limit');
       return false;
     }
-    if (!filter_var($email, FILTER_VALIDATE_EMAIL)) {
+    if ($email != 'hidden' && $email != NULL && !filter_var($email, FILTER_VALIDATE_EMAIL)) {
       $this->setErrorMessage('Invalid email address');
       return false;
     }
@@ -540,6 +540,9 @@ class User extends Base {
       }
     }
 
+    // If we hide our email or it's not set, fetch current one to update
+    if ($email == 'hidden' || $email == NULL)
+      $email = $this->getUserEmailById($userID);
     // We passed all validation checks so update the account
     $stmt = $this->mysqli->prepare("UPDATE $this->table SET ap_threshold = ?, donate_percent = ?, email = ?, timezone = ?, is_anonymous = ? WHERE id = ?");
     if ($this->checkStmt($stmt) && $stmt->bind_param('ddssii', $threshold, $donate, $email, $timezone, $is_anonymous, $userID) && $stmt->execute()) {

--- a/templates/bootstrap/account/edit/detail.tpl
+++ b/templates/bootstrap/account/edit/detail.tpl
@@ -28,7 +28,7 @@
             {/if}
             <div class="form-group">
               <label>E-Mail</label>
-              {nocache}<input class="form-control" type="text" name="email" value="{$GLOBAL.userdata.email|escape}" size="20" {if $GLOBAL.twofactor.enabled && $GLOBAL.twofactor.options.details && !$DETAILSUNLOCKED}id="disabledInput" disabled{/if}/>{/nocache}
+              {nocache}<input class="form-control" type="text" name="email" value="hidden" size="20" {if $GLOBAL.twofactor.enabled && $GLOBAL.twofactor.options.details && !$DETAILSUNLOCKED}id="disabledInput" disabled{/if}/>{/nocache}
             </div>
             <div class="form-group">
               <label>Timezone</label>


### PR DESCRIPTION
Will hide your e-mail address on your account screen. This should make stealing coins a bit harder since a pools password and email can not be used to login to a mail provider anymore.
