### PR TITLE
Preliminary support for Memcache SASL authentication

### DIFF
--- a/include/admin_checks.php
+++ b/include/admin_checks.php
@@ -34,6 +34,10 @@ if (@$_SESSION['USERDATA']['is_admin'] && $user->isAdmin(@$_SESSION['USERDATA'][
     }
     if (class_exists('Memcached')) {
       $memcache_test = @new Memcached();
+      if ($config['memcache']['sasl']) {
+        $memcache_test->setOption(Memcached::OPT_BINARY_PROTOCOL, true);
+        $memcache_test->setSaslAuthData($config['memcache']['sasl']['username'], $config['memcache']['sasl']['password']);
+      }
       $memcache_test_add = @$memcache_test->addServer($config['memcache']['host'], $config['memcache']['port']);
       $randmctv = rand(5,10);
       $memcache_test_set = @$memcache_test->set('test_mpos_setval', $randmctv);

--- a/include/classes/statscache.class.php
+++ b/include/classes/statscache.class.php
@@ -19,6 +19,10 @@ class StatsCache {
         require_once(CLASS_DIR . '/memcached.class.php');
       }
       $this->cache = new Memcached();
+      if ($config['memcache']['sasl']) {
+        $this->cache->setOption(Memcached::OPT_BINARY_PROTOCOL, true);
+        $this->cache->setSaslAuthData($config['memcache']['sasl']['username'], $config['memcache']['sasl']['password']) or die("failed!");
+      }
     }
   }
 

--- a/include/config/global.inc.dist.php
+++ b/include/config/global.inc.dist.php
@@ -268,6 +268,9 @@ $config['memcache']['keyprefix'] = 'mpos_';
 $config['memcache']['expiration'] = 90;
 $config['memcache']['splay'] = 15;
 $config['memcache']['force']['contrib_shares'] = false;
+$config['memcache']['sasl'] = false;
+$config['memcache']['sasl']['username'] = '';
+$config['memcache']['sasl']['password'] = '';
 
 /**
  * Cookies


### PR DESCRIPTION
Have preliminarily tested this, admin checks, cronjobs, normal functionality etc all seem to work okay.

Disabled by default as most distros I've looked at disable SASL support in Memcached and libmemcached.
