### PR TITLE
[UPDATE] Store coin auto payout in coin_addresses table per coin

### DIFF
--- a/include/classes/transaction.class.php
+++ b/include/classes/transaction.class.php
@@ -446,7 +446,7 @@ class Transaction extends Base {
       SELECT
       a.id,
       a.username,
-      a.ap_threshold,
+      ca.ap_threshold,
       ca.coin_address,
       p.id AS payout_id,
       IFNULL(

--- a/include/classes/transaction.class.php
+++ b/include/classes/transaction.class.php
@@ -355,7 +355,7 @@ class Transaction extends Base {
       SELECT
         a.id,
         a.username,
-        a.ap_threshold,
+        ca.ap_threshold,
         ca.coin_address,
         IFNULL(
             (
@@ -371,9 +371,9 @@ class Transaction extends Base {
       ON t.account_id = a.id
       LEFT JOIN " . $this->coin_address->getTableName() . " AS ca
       ON ca.account_id = a.id
-      WHERE t.archived = 0 AND a.ap_threshold > 0 AND ca.coin_address IS NOT NULL AND ca.coin_address != '' AND ca.currency = ?
+      WHERE t.archived = 0 AND ca.ap_threshold > 0 AND ca.coin_address IS NOT NULL AND ca.coin_address != '' AND ca.currency = ?
       GROUP BY t.account_id
-      HAVING confirmed > a.ap_threshold AND confirmed > " . $this->config['txfee_auto'] . "
+      HAVING confirmed > ca.ap_threshold AND confirmed > " . $this->config['txfee_auto'] . "
       LIMIT ?");
     if ($this->checkStmt($stmt) && $stmt->bind_param('si', $this->config['currency'], $limit) && $stmt->execute() && $result = $stmt->get_result())
       return $result->fetch_all(MYSQLI_ASSOC);

--- a/include/version.inc.php
+++ b/include/version.inc.php
@@ -2,7 +2,7 @@
 $defflip = (!cfip()) ? exit(header('HTTP/1.1 401 Unauthorized')) : 1;
 
 define('MPOS_VERSION', '1.0.2');
-define('DB_VERSION', '1.0.0');
+define('DB_VERSION', '1.0.1');
 define('CONFIG_VERSION', '1.0.0');
 define('HASH_VERSION', 1);
 

--- a/sql/000_base_structure.sql
+++ b/sql/000_base_structure.sql
@@ -27,7 +27,6 @@ CREATE TABLE IF NOT EXISTS `accounts` (
   `api_key` varchar(255) DEFAULT NULL,
   `token` varchar(65) DEFAULT NULL,
   `donate_percent` float DEFAULT '0',
-  `ap_threshold` float DEFAULT '0',
   PRIMARY KEY (`id`),
   UNIQUE KEY `username` (`username`),
   UNIQUE KEY `email` (`email`)
@@ -56,6 +55,7 @@ CREATE TABLE IF NOT EXISTS `coin_addresses` (
   `account_id` int(11) NOT NULL,
   `currency` varchar(5) NOT NULL,
   `coin_address` varchar(255) NOT NULL,
+  `ap_threshold` float DEFAULT '0',
   PRIMARY KEY (`id`),
   UNIQUE KEY `coin_address` (`coin_address`),
   KEY `account_id` (`account_id`)

--- a/sql/000_base_structure.sql
+++ b/sql/000_base_structure.sql
@@ -142,7 +142,7 @@ CREATE TABLE IF NOT EXISTS `settings` (
   UNIQUE KEY `setting` (`name`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
-INSERT INTO `settings` (`name`, `value`) VALUES ('DB_VERSION', '1.0.0');
+INSERT INTO `settings` (`name`, `value`) VALUES ('DB_VERSION', '1.0.1');
 
 CREATE TABLE IF NOT EXISTS `shares` (
   `id` bigint(30) NOT NULL AUTO_INCREMENT,

--- a/upgrade/definitions/1.0.0_to_1.0.1.inc.php
+++ b/upgrade/definitions/1.0.0_to_1.0.1.inc.php
@@ -10,7 +10,7 @@ function run_101() {
 
   // Upgrade specific variables
   $aSql[] = "ALTER TABLE `" . $coin_address->getTableName() . "` ADD ap_threshold float DEFAULT '0'";
-  $aSql[] = "UPDATE " . $coin_address->getTableName() . " AS ca LEFT JOIN " . $user->getTableName() . " AS a ON a.id = ca.account_id SET ca.coin_address = a.coin_address";
+  $aSql[] = "UPDATE " . $coin_address->getTableName() . " AS ca LEFT JOIN " . $user->getTableName() . " AS a ON a.id = ca.account_id SET ca.ap_threshold = a.ap_threshold";
   $aSql[] = "ALTER TABLE `" . $user->getTableName() . "` DROP `ap_threshold`";
   $aSql[] = "UPDATE " . $setting->getTableName() . "    SET value = '1.0.1' WHERE name = 'DB_VERSION'";
 

--- a/upgrade/definitions/1.0.0_to_1.0.1.inc.php
+++ b/upgrade/definitions/1.0.0_to_1.0.1.inc.php
@@ -1,0 +1,32 @@
+<?php
+function run_101() {
+  // Ugly but haven't found a better way
+  global $setting, $config, $coin_address, $user, $mysqli;
+
+  // Version information
+  $db_version_old = '1.0.0';  // What version do we expect
+  $db_version_new = '1.0.1';  // What is the new version we wish to upgrade to
+  $db_version_now = $setting->getValue('DB_VERSION');  // Our actual version installed
+
+  // Upgrade specific variables
+  $aSql[] = "ALTER TABLE `" . $coin_address->getTableName() . "` ADD ap_threshold float DEFAULT '0'";
+  $aSql[] = "UPDATE " . $coin_address->getTableName() . " AS ca LEFT JOIN " . $user->getTableName() . " AS a ON a.id = ca.account_id SET ca.coin_address = a.coin_address";
+  $aSql[] = "ALTER TABLE `" . $user->getTableName() . "` DROP `ap_threshold`";
+  $aSql[] = "UPDATE " . $setting->getTableName() . "    SET value = '1.0.1' WHERE name = 'DB_VERSION'";
+
+  if ($db_version_now == $db_version_old && version_compare($db_version_now, DB_VERSION, '<')) {
+    // Run the upgrade
+    echo '- Starting database migration to version ' . $db_version_new . PHP_EOL;
+    foreach ($aSql as $sql) {
+      echo '-  Preparing: ' . $sql . PHP_EOL;
+      $stmt = $mysqli->prepare($sql);
+      if ($stmt && $stmt->execute()) {
+        echo '-    success' . PHP_EOL;
+      } else {
+        echo '-    failed: ' . $mysqli->error . PHP_EOL;
+        exit(1);
+      }
+    }
+  }
+}
+?>


### PR DESCRIPTION
Quick update on the way we store the Auto Payout Threshold for accounts:

* Added `ap_threshold` to `coin_addresses` table
* Migrate users settings from accounts table to `coin_addresses` table for the current MPOS instance
* Delete `ap_threshold` from `accounts` table
* Update base SQL structure for new instances

Also update some classes to reflect this change, but this needs some testing before I will merge this.