### PR TITLE
[UPDATE] Shared DB Behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,11 @@
 ---------------------
 
 * Allow SSO accross MPOS pools
-  * Added a new config option `$config['db']['shared']['name']`, defaults to `$config['db']['name']`
-  * Will access `accounts` and `pool_workers` on shared table
+  * Added a new config options
+    * `$config['db']['shared']['acounts']`, defaults to `$config['db']['name']`
+    * `$config['db']['shared']['workers']`, defaults to `$config['db']['name']`
+    * `$config['db']['shared']['news']`, defaults to `$config['db']['name']`
+  * Will access `accounts`, `pool_workers` and `news` on shared table
   * Does not allow splitting `accounts` and `pool_woker` across database hosts
   * Required `$config['cookie']['domain']` to be set
     * You need to use the top domain shared between hosts as the setting

--- a/include/bootstrap.php
+++ b/include/bootstrap.php
@@ -14,6 +14,16 @@ $quickstartlink = "<a href='https://github.com/MPOS/php-mpos/wiki/Quick-Start-Gu
 if (!include_once(INCLUDE_DIR . '/config/global.inc.dist.php')) die('Unable to load base global config from ['.INCLUDE_DIR. '/config/global.inc.dist.php' . '] - '.$quickstartlink);
 if (!@include_once(INCLUDE_DIR . '/config/global.inc.php')) die('Unable to load your global config from ['.INCLUDE_DIR. '/config/global.inc.php' . '] - '.$quickstartlink);
 
+// Check for a shared account database and set to default DB if unset
+if (!isset($config['db']['shared']['accounts']))
+  $config['db']['shared']['accounts'] = $config['db']['name'];
+// Check for a shared worker database and set to default DB if unset
+if (!isset($config['db']['shared']['workers']))
+  $config['db']['shared']['workers'] = $config['db']['name'];
+// Check for a shared news database and set to default DB if unset
+if (!isset($config['db']['shared']['news']))
+  $config['db']['shared']['news'] = $config['db']['name'];
+
 // load our security configs
 if (!include_once(INCLUDE_DIR . '/config/security.inc.dist.php')) die('Unable to load base security config from ['.INCLUDE_DIR. '/config/security.inc.dist.php' . '] - '.$quickstartlink);
 if (@file_exists(INCLUDE_DIR . '/config/security.inc.php')) include_once(INCLUDE_DIR . '/config/security.inc.php');

--- a/include/classes/coin_address.class.php
+++ b/include/classes/coin_address.class.php
@@ -12,7 +12,7 @@ class CoinAddress extends Base {
    **/
   public function __construct($config) {
     $this->setConfig($config);
-    $this->table = $this->config['db']['shared']['name'] . '.' . $this->table;
+    $this->table = $this->config['db']['shared']['accounts'] . '.' . $this->table;
   }
 
   /**

--- a/include/classes/news.class.php
+++ b/include/classes/news.class.php
@@ -5,6 +5,17 @@ class News extends Base {
   protected $table = 'news';
 
   /**
+   * We allow changing the database for shared accounts across pools
+   * Load the config on construct so we can assign the DB name
+   * @param config array MPOS configuration
+   * @return none
+   **/
+  public function __construct($config) {
+    $this->setConfig($config);
+    $this->table = $this->config['db']['shared']['news'] . '.' . $this->table;
+  }
+
+  /**
    * Get activation status of post
    * @param id int News ID
    * @return bool true or false
@@ -96,7 +107,7 @@ class News extends Base {
   }
 }
 
-$news = new News();
+$news = new News($config);
 $news->setDebug($debug);
 $news->setMysql($mysqli);
 $news->setUser($user);

--- a/include/classes/user.class.php
+++ b/include/classes/user.class.php
@@ -14,7 +14,7 @@ class User extends Base {
    **/
   public function __construct($config) {
     $this->setConfig($config);
-    $this->table = $this->config['db']['shared']['name'] . '.' . $this->table;
+    $this->table = $this->config['db']['shared']['accounts'] . '.' . $this->table;
   }
 
   // get and set methods

--- a/include/classes/worker.class.php
+++ b/include/classes/worker.class.php
@@ -12,7 +12,7 @@ class Worker extends Base {
    **/
   public function __construct($config) {
     $this->setConfig($config);
-    $this->table = $this->config['db']['shared']['name'] . '.' . $this->table;
+    $this->table = $this->config['db']['shared']['workers'] . '.' . $this->table;
   }
 
   /**

--- a/include/config/global.inc.dist.php
+++ b/include/config/global.inc.dist.php
@@ -54,7 +54,11 @@ $config['db']['user'] = 'someuser';
 $config['db']['pass'] = 'somepass';
 $config['db']['port'] = 3306;
 $config['db']['name'] = 'mpos';
-$config['db']['shared']['name'] = $config['db']['name'];
+// Disabled by default and set in bootstrap if unset, but left in here so
+// people know it exists
+// $config['db']['shared']['accounts'] = $config['db']['name'];
+// $config['db']['shared']['workers'] = $config['db']['name'];
+// $config['db']['shared']['news'] = $config['db']['name'];
 
 /**
  * Local wallet RPC


### PR DESCRIPTION
* Default to standard DB if nothing is set
* Separate Accounts and Pool Workers shared DB
* Added shared News DB
* New config options added
   * `$config['db']['shared']['accounts']`
   * `$config['db']['shared']['workers']`
   * `$config['db']['shared']['news']`

Re-created #2407 with proper target branch.