### PR TITLE
Add Anonymous check for blockfinder email

### DIFF
--- a/cronjobs/findblock.php
+++ b/cronjobs/findblock.php
@@ -157,8 +157,12 @@ if (empty($aAllBlocks)) {
         // Notify users
         $aAccounts = $notification->getNotificationAccountIdByType('new_block');
         if (is_array($aAccounts)) {
-		
-          $finder = $user->getUserName($iAccountId);
+          if ($user->getUserNameAnon($iAccountId) == 1) {
+                $finder = "Anonymous";
+          } else {
+               $finder = $user->getUserName($iAccountId);
+          }
+
           foreach ($aAccounts as $aData) {
             $aMailData['height'] = $aBlock['height'];
             $aMailData['subject'] = 'New Block';

--- a/include/classes/user.class.php
+++ b/include/classes/user.class.php
@@ -31,6 +31,9 @@ class User extends Base {
   public function getUserName($id) {
     return $this->getSingle($id, 'username', 'id');
   }
+  public function getUserNameAnon($id) {
+    return $this->getSingle($id, 'is_anonymous', 'id');
+  }
   public function getUserNameByEmail($email) {
     return $this->getSingle($email, 'username', 'email', 's');
   }


### PR DESCRIPTION
A Member of my pool notified me that he was still being listed in block finder emails even though he had turned on anonymous mining.  I added these few lines of code to fix on my implementation to check if anonymous mining is turned on before sending the notification emails.