### PR TITLE
repair 'User Information' table in 'Admin Panel > Users > user Info' …

### DIFF
--- a/templates/bootstrap/admin/user/default.tpl
+++ b/templates/bootstrap/admin/user/default.tpl
@@ -95,7 +95,7 @@
                 <th class="h6" style="padding-right:10px">Est. Donation</th>
                 <th class="h6" style="padding-right:10px">Est. Payout</th>
 {else}
-                <th class="h6" colspan="2" style="padding-right:10px">Est. 24 Hours</th>
+                <th class="h6" style="padding-right:10px">Est. 24 Hours</th>
 {/if}
                 <th class="h6" style="padding-right:10px">Balance</th>
                 <th class="h6" style="padding-right:10px">Reg. Date</th>
@@ -118,7 +118,7 @@
                 <td>{$USERS[user].estimates.donation|number_format:"8"}</td>
                 <td>{$USERS[user].estimates.payout|number_format:"8"}</td>
 {else}
-                <td colspan="2">{$USERS[user].estimates.hours24|number_format:"8"}</td>
+                <td>{$USERS[user].estimates.hours24|number_format:"8"}</td>
 {/if}
                 <td>{$USERS[user].balance|number_format:"8"}</td>
                 <td>{$USERS[user].signup_timestamp|date_format:$GLOBAL.config.date}</td>


### PR DESCRIPTION
I have repaired 'User Information' table in 'Admin Panel > Users > user Info' in calse payout_system=pps.

In 'Admin Panel > Users > user Info' when I clicked 'Search' , mpos displayed following error window.
It is shown only if payout_system is pps at global.inc.php.
<img width="532" alt="error2015-07-11 9 55 39" src="https://cloud.githubusercontent.com/assets/7654743/8631519/2c5ce390-27b3-11e5-87d5-6484e7eafe60.png">

In templates/bootstrap/admin/user/default.tpl I have removed "colspan=2" to display no error message.