### PR TITLE
minerd manual says it must be "-a scrypt" not "-a --scrypt"

### DIFF
--- a/templates/bootstrap/gettingstarted/default.tpl
+++ b/templates/bootstrap/gettingstarted/default.tpl
@@ -42,7 +42,7 @@
       <li>BFGMiner</li>
       <pre>bfgminer {if $GLOBAL.config.algorithm == 'scrypt'}--scrypt {/if}-o stratum+tcp://{$SITESTRATUMURL|default:$smarty.server.SERVER_NAME}:{$SITESTRATUMPORT|default:"3333"} -u <em>Weblogin</em>.<em>WorkerName</em> -p <em>WorkerPassword</em></pre>
       <li>MinerD</li>
-      <pre>minerd -a {if $GLOBAL.config.algorithm == 'scrypt'}--scrypt {/if}-t 6 -s 4 -o stratum+tcp://{$SITESTRATUMURL|default:$smarty.server.SERVER_NAME}:{$SITESTRATUMPORT|default:"3333"} -u <em>Weblogin</em>.<em>WorkerName</em> -p <em>WorkerPassword</em></pre>
+      <pre>minerd -a {if $GLOBAL.config.algorithm == 'scrypt'}scrypt {/if}-t 6 -s 4 -o stratum+tcp://{$SITESTRATUMURL|default:$smarty.server.SERVER_NAME}:{$SITESTRATUMPORT|default:"3333"} -u <em>Weblogin</em>.<em>WorkerName</em> -p <em>WorkerPassword</em></pre>
       {if $GLOBAL.config.algorithm == 'scrypt'}
       <li>Cudaminer For NVIDIA Cards</li>
 	  <pre>cudaminer -o stratum+tcp://{$SITESTRATUMURL|default:$smarty.server.SERVER_NAME}:{$SITESTRATUMPORT|default:"3333"} -u <em>Weblogin</em>.<em>WorkerName</em> -p <em>WorkerPassword</em></pre>


### PR DESCRIPTION
Tried minerd from https://github.com/pooler/cpuminer v 2.4.4 and used the settings that are written into default.tpl. Minerd complains then: 
```
./minerd: unknown algorithm -- '--scrypt'
Try `minerd --help' for more information.
```
minerd --help says

```
Usage: minerd [OPTIONS]
Options:
  -a, --algo=ALGO       specify the algorithm to use
                          scrypt    scrypt(1024, 1, 1) (default)
                          scrypt:N  scrypt(N, 1, 1)
                          sha256d   SHA-256d
```
So we just need to remove the --  next to the algorithm and then it works like expected.

```
[2016-05-10 20:22:38] 6 miner threads started, using 'scrypt' algorithm.
[2016-05-10 20:22:38] Stratum requested work restart
```
