### PR TITLE
[ADDED] Temporarily disable all crons on pool maintenance

### DIFF
--- a/cronjobs/shared.inc.php
+++ b/cronjobs/shared.inc.php
@@ -69,6 +69,12 @@ $log->LogDebug('Starting ' . $cron_name);
 // Load the start time for later runtime calculations for monitoring
 $cron_start[$cron_name] = microtime(true);
 
+// Skip all crons if admin enabled pool maintenance
+if ($setting->getValue('maintenance')) {
+  $log->logInfo('Cronjobs disabled due to pool maintenance');
+  $monitoring->endCronjob($cron_name, 'E0083', 2, true, false);
+}
+
 // Check if our cron is activated
 if ($monitoring->isDisabled($cron_name)) {
   $log->logFatal('Cronjob is currently disabled due to errors, use -f option to force running cron.');

--- a/include/classes/monitoring.class.php
+++ b/include/classes/monitoring.class.php
@@ -131,7 +131,7 @@ class Monitoring extends Base {
         $this->setErrorMessage('Failed to send mail notification');
     }
     if ($fatal) {
-      if ($exitCode != 0) $this->setStatus($cron_name . "_disabled", "yesno", 1);
+      if ($exitCode == 1) $this->setStatus($cron_name . "_disabled", "yesno", 1);
       exit($exitCode);
     }
   }

--- a/include/config/error_codes.inc.php
+++ b/include/config/error_codes.inc.php
@@ -78,3 +78,4 @@ $aErrorCodes['E0079'] = 'Wallet does not cover payouts total amount';
 $aErrorCodes['E0080'] = 'No new unaccounted shares since last run';
 $aErrorCodes['E0081'] = 'Failed to insert new block into database';
 $aErrorCodes['E0082'] = 'Block does not supply any usable confirmation information';
+$aErrorCodes['E0083'] = 'Maintenance mode enabled, skipped';

--- a/templates/bootstrap/admin/monitoring/default.tpl
+++ b/templates/bootstrap/admin/monitoring/default.tpl
@@ -25,6 +25,8 @@
                 {if $event.type == 'okerror'}
                   {if $event.value == 0}
                     <font color="green">OK</font>
+		  {else if $event.value == 2}
+                    <font color="orange">WARN</font>
                   {else}
                     <font color="red">ERROR</font>
                   {/if}


### PR DESCRIPTION
This should help pool operators with controlled shutdowns of machines. Instead of just forcing a shutdown and potentially breaking the crons (having to run them with -f afterwards), we allow a pool op to set maintenance mode and temporarily disable the cronjobs. After a reboot and disabling maintenance mode, crons will pick up again if all services required (coind) are available.

This should make a reboot easier.