### PR TITLE
[UPDATE] Catch missing theme folder from website_theme setting

### DIFF
--- a/include/smarty_globals.inc.php
+++ b/include/smarty_globals.inc.php
@@ -224,6 +224,10 @@ if ($motd = $setting->getValue('system_motd')) {
 if ($setting->getValue('website_theme') == "mpos")
   $_SESSION['POPUP'][] = array('CONTENT' => 'You are using an old Theme that will not be maintained in the future.', 'TYPE' => 'alert alert-warning');
 
+// Check we can load the theme at all
+if ( !in_array($setting->getValue('website_theme'), $template->getThemes()))
+  die('Unable to find your selected theme `' . $setting->getValue('website_theme') . '` in the list of available themes. Please reset your `website_theme` setting in your database.');
+
 // So we can display additional info
 $smarty->assign('DEBUG', $config['DEBUG']);
 


### PR DESCRIPTION
As described, catch if a selected theme does not exist (anymore) in the template folder.