### PR TITLE
Implement Read/Write Split directly on PHP / Fixed statistics->graphs page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ tests/_output/*
 
 # NetBeans Project Directory
 /nbproject/*
+
+# No need for composer.lock
+composer.lock

--- a/include/autoloader.inc.php
+++ b/include/autoloader.inc.php
@@ -9,6 +9,7 @@ require_once(CLASS_DIR . '/debug.class.php');
 if ($config['mysql_filter']) {
   require_once(CLASS_DIR . '/strict.class.php');
 }
+require_once(INCLUDE_DIR . '/classes/mysqlims.class.php');
 require_once(INCLUDE_DIR . '/database.inc.php');
 require_once(INCLUDE_DIR . '/config/memcache_keys.inc.php');
 require_once(INCLUDE_DIR . '/config/error_codes.inc.php');

--- a/include/classes/mysqlims.class.php
+++ b/include/classes/mysqlims.class.php
@@ -1,0 +1,85 @@
+<?php
+/*
+ * This class will run queries on master/slave servers depending on the query itself.
+ */
+class mysqlims extends mysqli
+{
+    private $mysqliW;
+    private $mysqliR = null;
+
+    /*
+     * Pass main and slave connection arrays to the constructor, and strict as true/false
+     *
+     * @param array $main
+     * @param array $slave
+     * @param boolean $strict
+     *
+     * @return void
+     */
+    public function __construct($main, $slave = false, $strict = false)
+    {
+        var_dump($main);
+        var_dump($slave);
+        if ($strict) {
+            $this->mysqliW = new mysqli_strict($main['host'],
+                $main['user'], $main['pass'],
+                $main['name'], $main['port']);
+            if ($slave && is_array($slave) && isset($slave['enabled']) && $slave['enabled']
+                === true) {
+                $this->mysqliR = new mysqli_strict($slave['host'],
+                    $slave['user'], $slave['pass'],
+                    $slave['name'], $slave['port']);
+            }
+        } else {
+            $this->mysqliW = new mysqli($main['host'],
+                $main['user'], $main['pass'],
+                $main['name'], $main['port']);
+            if ($slave && is_array($slave) && isset($slave['enabled']) && $slave['enabled']
+                === true) {
+                $this->mysqliR = new mysqli($slave['host'],
+                    $slave['user'], $slave['pass'],
+                    $slave['name'], $slave['port']);
+            }
+        }
+
+        if ($this->mysqliW->connect_errno) {
+            throw new Exception("Failed to connect to MySQL: (".$this->mysqliW->connect_errno.") ".$this->mysqliW->connect_error);
+        }
+
+        if ($this->mysqliR->connect_errno) {
+            throw new Exception("Failed to connect to MySQL: (".$this->mysqliR->connect_errno.") ".$this->mysqliR->connect_error);
+        }
+    }
+
+    /*
+     * Override standard mysqli_prepare to select master/slave server
+     * @param $string query
+     *
+     * @return mysqli_stmt
+     */
+    public function prepare($query)
+    {
+        if (stripos($query, "SELECT") && stripos($query, "FOR UPDATE") === false && $this->mysqliR !== null) {
+            return $this->mysqliR->prepare($query);
+        } else {
+            return $this->mysqliW->prepare($query);
+        }
+    }
+
+    /*
+     * Override standard mysqli_query to select master/slave server
+     * @param string $query
+     * @param int $resultmode
+     *
+     * @return boolean
+     * @return mixed
+     */
+    public function query($query, $resultmode = MYSQLI_STORE_RESULT)
+    {
+        if (stripos($query, "SELECT") && stripos($query, "FOR UPDATE") === false && $this->mysqliR !== null) {/* Use readonly server */
+            return $this->mysqliR->query($query, $resultmode);
+        } else {
+            return $this->mysqliW->query($query, $resultmode);
+        }
+    }
+}

--- a/include/classes/mysqlims.class.php
+++ b/include/classes/mysqlims.class.php
@@ -18,8 +18,6 @@ class mysqlims extends mysqli
      */
     public function __construct($main, $slave = false, $strict = false)
     {
-        var_dump($main);
-        var_dump($slave);
         if ($strict) {
             $this->mysqliW = new mysqli_strict($main['host'],
                 $main['user'], $main['pass'],

--- a/include/config/global.inc.dist.php
+++ b/include/config/global.inc.dist.php
@@ -60,6 +60,18 @@ $config['db']['name'] = 'mpos';
 // $config['db']['shared']['workers'] = $config['db']['name'];
 // $config['db']['shared']['news'] = $config['db']['name'];
 
+
+/**
+ * Setup read-only/slave database server for selects (read queries)
+**/
+$config['db-ro']['enabled'] = false;
+$config['db-ro']['host'] = 'localhost';
+$config['db-ro']['user'] = 'someuser';
+$config['db-ro']['pass'] = 'somepass';
+$config['db-ro']['port'] = 3306;
+$config['db-ro']['name'] = 'mpos';
+
+ 
 /**
  * Local wallet RPC
  *  RPC configuration for your daemon/wallet

--- a/include/database.inc.php
+++ b/include/database.inc.php
@@ -3,13 +3,14 @@ $defflip = (!cfip()) ? exit(header('HTTP/1.1 401 Unauthorized')) : 1;
 
 // Instantiate class, we are using mysqlng
 if ($config['mysql_filter']) {
-  $mysqli = new mysqli_strict($config['db']['host'], $config['db']['user'], $config['db']['pass'], $config['db']['name'], $config['db']['port']);
+  $mysqli = new mysqlims($config['db'],$config['db-ro'], true);
 } else {
-  $mysqli = new mysqli($config['db']['host'], $config['db']['user'], $config['db']['pass'], $config['db']['name'], $config['db']['port']);
+  $mysqli = new mysqlims($config['db'],$config['db-ro'], false);
 }
 
-// Check if read-only and quit if it is on
-if ($mysqli->query('/* MYSQLND_MS_MASTER_SWITCH */SELECT @@global.read_only AS read_only')->fetch_object()->read_only == 1) {
+// Check if read-only and quit if it is on, disregard if slave is enabled
+
+if ($mysqli->query('/* MYSQLND_MS_MASTER_SWITCH */SELECT @@global.read_only AS read_only')->fetch_object()->read_only == 1 && $config['db-ro']['enabled'] === false ) {
   die('Database is in READ-ONLY mode');
 }
 

--- a/templates/bootstrap/statistics/graphs/default.tpl
+++ b/templates/bootstrap/statistics/graphs/default.tpl
@@ -2,7 +2,7 @@
 $(function () {
   var hashChart = Morris.Line({
     element: 'hashrate-area-chart',
-    data: {$YOURMININGSTATS},
+    data: {$YOURMININGSTATS nofilter},
     xkey: 'time',
     ykeys: ['hashrate'],
     labels: ['Hashrate'],
@@ -17,7 +17,7 @@ $(function () {
 
   var workersChart = Morris.Line({
     element: 'workers-area-chart',
-    data: {$YOURMININGSTATS},
+    data: {$YOURMININGSTATS nofilter},
     xkey: 'time',
     ykeys: ['workers'],
     labels: ['Workers'],
@@ -32,7 +32,7 @@ $(function () {
 
   var shareCharts= Morris.Line({
     element: 'sharerate-area-chart',
-    data: {$YOURMININGSTATS},
+    data: {$YOURMININGSTATS nofilter},
     xkey: 'time',
     ykeys: ['sharerate'],
     labels: ['Sharerate'],


### PR DESCRIPTION
The statistics->graphs page was not working because smarty was escaping html chars, thus breaking javascript.

Since the mysqlnd_ms extension does not work on php7, only php5, I implemented a simple Read/Write query splitting.

Tested while monitoring both master/slave instances.
