### PR TITLE
Added Yobit Api Call

### DIFF
--- a/include/classes/tools.class.php
+++ b/include/classes/tools.class.php
@@ -87,6 +87,8 @@ class Tools extends Base {
       return 'c-cex';
     } else if (preg_match('/bittrex.com/', $url)) {
       return 'bittrex';
+    } else if (preg_match('/yobit.net/', $url)) {
+      return 'yobit';
     }
     $this->setErrorMessage("API URL unknown");
     return false;
@@ -131,6 +133,9 @@ class Tools extends Base {
       	case 'bittrex':
       	  return @$aData['result']['Last'];
       	  break;
+        case 'yobit':
+          return @$aData[$this->config['price']['target']]['last'];
+          break;
       }
     } else {
       $this->setErrorMessage("Got an invalid response from ticker API");


### PR DESCRIPTION
Change Allows Site admin to pull last price from this exchange.
Configuration example

$config['price']['enabled'] = true;
$config['price']['url'] = 'https://yobit.net/api/3/ticker/';
$config['price']['target'] = 'btc_usd'; // API call to pair , the pair is used as target due to yobit api using the pair to encapsulate data should be noted that target must be in lower case at all times
$config['price']['currency'] = 'BTC'; // Market now expanded to additional pairs {Coin}_btc / {Coin}_eth /{Coin}_doge / {Coin}_waves / {Coin}_usd / {Coin}_rur