### PR TITLE
Fix SQL in cleaning up old notifications

### DIFF
--- a/include/classes/notification.class.php
+++ b/include/classes/notification.class.php
@@ -190,7 +190,7 @@ class Notification extends Mail {
   public function cleanupNotifications($days=7) {
     $failed = 0;
     $this->deleted = 0;
-    $stmt = $this->mysqli->prepare("DELETE FROM $this->table WHERE time < (NOW() - ? * 24 * 60 * 60)");
+    $stmt = $this->mysqli->prepare("DELETE FROM $this->table WHERE time < (NOW() - INTERVAL ? DAY)");
     if (! ($this->checkStmt($stmt) && $stmt->bind_param('i', $days) && $stmt->execute())) {
       $failed++;
     } else {


### PR DESCRIPTION
Subtracting numbers from datetime causes wrong value, or raises error depending on MySQL version/configurations. It leads deleting notification wrongly or failed to do so.

This PR solves above issue by using `INTERVAL` to make appropriate value for date calculation. 

Below confimed in MySQL8.0
```
mysql> select NOW() \G
*************************** 1. row ***************************
NOW(): 2018-01-01 13:25:56

mysql> select NOW() - 7 * 24 * 60 * 60\G
*************************** 1. row ***************************
NOW() - 7 * 24 * 60 * 60: 20180100527811
```
The result `20180100527811` is wrong. It is `20180101132611(string transformation by YYYYMMDDHHmmSS) - 7*24*60*60`

```
mysql> select NOW() - INTERVAL 7 DAY\G
*************************** 1. row ***************************
NOW() - INTERVAL 7 DAY: 2017-12-25 13:28:18
```

I tried in MySQL 5.7 and had same result. And it ends up with error when this calculation used in `WHERE` clause.