### PR TITLE
Add -t option to ignore too old cronjob active flag

### DIFF
--- a/cronjobs/run-maintenance.sh
+++ b/cronjobs/run-maintenance.sh
@@ -47,16 +47,25 @@ fi
 ME=$( basename $0 )
 
 # Overwrite some settings via command line arguments
-while getopts "hfvp:d:" opt; do
+while getopts "hfvt:p:d:" opt; do
   case "$opt" in
     h|\?)
-      echo "Usage: $0 [-v] [-p PHP_BINARY] [-d SUBFOLDER]";
+      echo "Usage: $0 [-v] [-f] [-t TIME_IN_SEC] [-p PHP_BINARY] [-d SUBFOLDER]";
       exit 0
       ;;
     v) VERBOSE=1 ;;
     f) PHP_OPTS="$PHP_OPTS -f";;
     p) PHP_BIN=$OPTARG ;;
     d) SUBFOLDER=$OPTARG ;;
+    t)
+      if [[ $OPTARG =~ ^[0-9]+$ ]]; then
+        TIMEOUT=$OPTARG
+        PHP_OPTS="$PHP_OPTS -t $OPTARG"
+      else
+        echo "Option -t requires an integer" >&2
+        exit 1
+      fi
+    ;;
     :)
       echo "Option -$OPTARG requires an argument." >&2
       exit 1
@@ -101,6 +110,16 @@ fi
 
 # Our PID of this shell
 PID=$$
+
+# If $PIDFILE exists and older than the time specified by -t, remove it.
+if [[ -e $PIDFILE ]]; then
+  if [[ -n $TIMEOUT ]] && \
+     [[ $(( $(date +%s) - $(stat -c %Y $PIDFILE) )) -gt $TIMEOUT ]]; then
+    echo "$PIDFILE exists but older than the time you specified in -t option ($TIMEOUT sec)."
+    echo "Removing PID file."
+    rm $PIDFILE
+  fi
+fi
 
 if [[ -e $PIDFILE ]]; then
   echo "Cron seems to be running already"

--- a/cronjobs/run-statistics.sh
+++ b/cronjobs/run-statistics.sh
@@ -47,16 +47,25 @@ fi
 ME=$( basename $0 )
 
 # Overwrite some settings via command line arguments
-while getopts "hfvp:d:" opt; do
+while getopts "hfvt:p:d:" opt; do
   case "$opt" in
     h|\?)
-      echo "Usage: $0 [-v] [-p PHP_BINARY] [-d SUBFOLDER]";
+      echo "Usage: $0 [-v] [-f] [-t TIME_IN_SEC] [-p PHP_BINARY] [-d SUBFOLDER]";
       exit 0
       ;;
     v) VERBOSE=1 ;;
     f) PHP_OPTS="$PHP_OPTS -f";;
     p) PHP_BIN=$OPTARG ;;
     d) SUBFOLDER=$OPTARG ;;
+    t)
+      if [[ $OPTARG =~ ^[0-9]+$ ]]; then
+        TIMEOUT=$OPTARG
+        PHP_OPTS="$PHP_OPTS -t $OPTARG"
+      else
+        echo "Option -t requires an integer" >&2
+        exit 1
+      fi
+    ;;
     :)
       echo "Option -$OPTARG requires an argument." >&2
       exit 1
@@ -101,6 +110,16 @@ fi
 
 # Our PID of this shell
 PID=$$
+
+# If $PIDFILE exists and older than the time specified by -t, remove it.
+if [[ -e $PIDFILE ]]; then
+  if [[ -n $TIMEOUT ]] && \
+     [[ $(( $(date +%s) - $(stat -c %Y $PIDFILE) )) -gt $TIMEOUT ]]; then
+    echo "$PIDFILE exists but older than the time you specified in -t option ($TIMEOUT sec)."
+    echo "Removing PID file."
+    rm $PIDFILE
+  fi
+fi
 
 if [[ -e $PIDFILE ]]; then
   echo "Cron seems to be running already"

--- a/include/classes/monitoring.class.php
+++ b/include/classes/monitoring.class.php
@@ -61,6 +61,16 @@ class Monitoring extends Base {
   }
 
   /**
+   * Get the timestamp that last time a cronjob started
+   * @param name string Cronjob name
+   * @return int unix timestamp of last time the cronjob started
+   **/
+  public function getLastCronStarted($name) {
+    $aStatus = $this->getStatus($name . '_starttime');
+    return $aStatus['value'];
+  }
+
+  /**
    * Fetch a value from our table
    * @param name string Setting name
    * @return value string Value

--- a/include/config/error_codes.inc.php
+++ b/include/config/error_codes.inc.php
@@ -80,3 +80,4 @@ $aErrorCodes['E0081'] = 'Failed to insert new block into database';
 $aErrorCodes['E0082'] = 'Block does not supply any usable confirmation information';
 $aErrorCodes['E0083'] = 'Maintenance mode enabled, skipped';
 $aErrorCodes['E0084'] = 'Error updating %s table';
+$aErrorCodes['E0085'] = 'Cron disabled due to invalid arguments';


### PR DESCRIPTION
This PR adds `-t TIME_IN_SEC` option into the shell scripts for cronjobs.
**Example usage:** `run-statistics.sh -t 3600`  

I have had some experiences that cronjob didn't finished properly (e.g., due to connection interruption of DB or coind) and `${cron_name}_active` left `1`. It causes keeping the job from running in next execution until I note it and manually remove the flag by running the job with `-f` option. The miners had inconvenience suchs as no credits added or no cash outs for a long time.

With this `-t` option, the jobs ignore the active flag if the last job was started before than the user specified by this option. For example, `-t 3600` ignores the flag if it was started more than one hours ago. Note the option ignores PID file created by the shell script. By this option the cronjobs can automatically recovered from such a situation. 