### PR TITLE
added 300ms curl timeout for the push_notifications. otherwise the findblock cron will run default 300s timeout if a service goes down. (notifymyandroid is down.)

### DIFF
--- a/include/classes/push_notification/notifymyandroid.php
+++ b/include/classes/push_notification/notifymyandroid.php
@@ -24,6 +24,7 @@ class Notifications_NotifyMyAndroid implements IPushNotification {
     public function notify($message, $severity = 'info', $event = null){
         global $setting;
         curl_setopt_array($ch = curl_init(), array(
+			CURLOPT_TIMEOUT_MS => 300,
             CURLOPT_URL => "https://www.notifymyandroid.com/publicapi/notify",
             CURLOPT_POST => true,
             CURLOPT_RETURNTRANSFER => true,

--- a/include/classes/push_notification/pushover.php
+++ b/include/classes/push_notification/pushover.php
@@ -27,6 +27,7 @@
 		
 		public function notify($message, $severity = 'info', $event = null){
 			curl_setopt_array($ch = curl_init(), array(
+				CURLOPT_TIMEOUT_MS => 300,
 				CURLOPT_URL => "https://api.pushover.net/1/messages.json",
 				CURLOPT_POST => true,
 				CURLOPT_RETURNTRANSFER => true,


### PR DESCRIPTION
Cronjobs will run +300s because the running into an curl timeout because of notifymyandroid is down. running in production at https://vrm.n3rd3d.com and https://vrm.mining-pool.ovh