### PR TITLE
added 1500ms curl timeout for the push_notifications

### DIFF
--- a/include/classes/push_notification/notifymyandroid.php
+++ b/include/classes/push_notification/notifymyandroid.php
@@ -24,6 +24,7 @@ class Notifications_NotifyMyAndroid implements IPushNotification {
     public function notify($message, $severity = 'info', $event = null){
         global $setting;
         curl_setopt_array($ch = curl_init(), array(
+			CURLOPT_TIMEOUT_MS => 1500,
             CURLOPT_URL => "https://www.notifymyandroid.com/publicapi/notify",
             CURLOPT_POST => true,
             CURLOPT_RETURNTRANSFER => true,

--- a/include/classes/push_notification/notifymyandroid.php
+++ b/include/classes/push_notification/notifymyandroid.php
@@ -24,7 +24,6 @@ class Notifications_NotifyMyAndroid implements IPushNotification {
     public function notify($message, $severity = 'info', $event = null){
         global $setting;
         curl_setopt_array($ch = curl_init(), array(
-			CURLOPT_TIMEOUT_MS => 300,
             CURLOPT_URL => "https://www.notifymyandroid.com/publicapi/notify",
             CURLOPT_POST => true,
             CURLOPT_RETURNTRANSFER => true,

--- a/include/classes/push_notification/pushover.php
+++ b/include/classes/push_notification/pushover.php
@@ -27,6 +27,7 @@
 		
 		public function notify($message, $severity = 'info', $event = null){
 			curl_setopt_array($ch = curl_init(), array(
+				CURLOPT_TIMEOUT_MS => 1500,
 				CURLOPT_URL => "https://api.pushover.net/1/messages.json",
 				CURLOPT_POST => true,
 				CURLOPT_RETURNTRANSFER => true,

--- a/include/classes/push_notification/pushover.php
+++ b/include/classes/push_notification/pushover.php
@@ -27,7 +27,6 @@
 		
 		public function notify($message, $severity = 'info', $event = null){
 			curl_setopt_array($ch = curl_init(), array(
-				CURLOPT_TIMEOUT_MS => 300,
 				CURLOPT_URL => "https://api.pushover.net/1/messages.json",
 				CURLOPT_POST => true,
 				CURLOPT_RETURNTRANSFER => true,


### PR DESCRIPTION
added 1500ms curl timeout for the push_notifications. otherwise the findblock cron will run default 300s timeout if a service goes down. (notifymyandroid is down.)

300ms are not enough for pushover working fine with 1000ms. increased it to 1500ms for high ping connections.